### PR TITLE
Fix evals.json skill_name to match skill directory

### DIFF
--- a/skills/github-actions-workflow-pro/evals/evals.json
+++ b/skills/github-actions-workflow-pro/evals/evals.json
@@ -1,5 +1,5 @@
 {
-  "skill_name": "github-action-workflow",
+  "skill_name": "github-actions-workflow-pro",
   "evals": [
     {
       "id": 0,


### PR DESCRIPTION
Part 1 of 11 in stack #13 (`gha-skill/evals-fix`, base `main`). Review bottom-up; each layer was diff-reviewed before its commit.

## Changes
- **Fix evals.json skill_name to match skill directory**

## Verification
- Baseline eval run (iteration-1) on the pre-rewrite skill; `make lint` clean.
- `make lint` clean at the layer's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yRNwbvpf198fiYZHgkt1w