### PR TITLE
Add security, speed, and audit references plus pin-action.sh

### DIFF
--- a/skills/github-actions-workflow-pro/references/audit.md
+++ b/skills/github-actions-workflow-pro/references/audit.md
@@ -1,0 +1,69 @@
+# Auditing existing workflows
+
+Read this when the user hands you one or more workflows to review, harden, secure, or speed up, or asks "what's wrong with my CI". The output is a report in the template below plus a proposed diff. The SKILL.md checklist still applies to any YAML you propose.
+
+## 1. Gate
+
+Before reading any YAML:
+
+- Locate the files: `.github/workflows/*.yml` and `*.yaml`, or the file the user pointed at. No files is a finding in itself: say so and stop.
+- Check the tools: `command -v actionlint zizmor gasa gh`. Report by name anything missing and continue with what is present. Recommend the missing tool at the end, do not install it.
+- `gasa` scans a repository, not a file, and needs `gh auth status` to pass. If auth fails, run the file-level tools only and say gasa was skipped.
+
+## 2. Run the tools, then read the YAML
+
+The tools are the source of truth for hard findings; run them first so your own reading fills gaps instead of duplicating rules the tools already enforce.
+
+```bash
+actionlint -format '{{json .}}' .github/workflows/*.y*ml
+zizmor --format json --offline .github/workflows/
+gasa run --format json --category workflows            # repo-level; add settings,updates if gh auth passes and the user wants admin checks
+```
+
+- `actionlint`: syntax, expression types, shellcheck on `run:` blocks, unknown runner labels.
+- `zizmor`: template injection, secrets outside environments, dangerous triggers, unpinned uses, excessive permissions. `--offline` skips audits that need the API; drop it when `gh auth status` passes and you want impostor-commit and stale-ref checks.
+- `gasa`: pinning, permissions, `pull_request_target`, Dependabot coverage, and (with `settings`) repo admin settings such as default token permissions and fork-PR approval. Run `gasa rules` for the current list and each rule's doc URL rather than restating them here.
+
+Then read each workflow once, top to bottom, against `references/security.md` and `references/speed.md`. Note anything the tools cannot see: a deploy job sharing a cancel-in-progress group with CI, a matrix of identical cells, a `write` grant no step uses, a release workflow with a path filter.
+
+## 3. Sort findings into hard and opinion
+
+- **Hard**: a tool rule fired, or the YAML violates a rule in `security.md` that has a concrete failure mode (injection, unpinned third-party action, `write-all`, `pull_request_target` in a public repo, static cloud keys). Cite the rule id (`zizmor: template-injection`, `gasa: workflows/action-version-pinning`, `security.md: pinned`) and `file:line`.
+- **Speed**: a rule from `speed.md` not applied where it would obviously help. Quantify when you can ("build job has no timeout; last run was 41 min").
+- **Opinion**: Bret's conventions with no failure mode attached: friendly names, filename conventions, `ghcr.io` default, reusable-workflow suggestions. Label each "opinion". A convention the repo already follows consistently overrides the opinion; say so instead of proposing churn.
+
+Skip anything a tool already enforces and reports cleanly; the reader has the tool output. Skip anything the repo has explicitly configured away (a `.gasa.yml` ignore, a `# zizmor: ignore[...]` comment) unless the ignore itself looks wrong.
+
+## 4. Report
+
+Use this shape. Empty sections stay in with "none".
+
+```markdown
+## Hard findings
+- <severity> `<rule id>` <file>:<line> — <what is wrong in one line>. Fix: <the change>.
+
+## Speed
+- <file>:<line> — <what is slow and why>. Fix: <the change>.
+
+## Opinions
+- <file> — <convention>, opinion. <one-line why it helps>.
+
+## Proposed diff
+<unified diff, or the full corrected file when most lines change>
+
+## Tools
+actionlint <version|absent>, zizmor <version|absent>, gasa <version|absent|skipped: reason>
+```
+
+Severity comes from the tool that reported it; for `security.md` rules use critical for injection and `pull_request_target` in public repos, high for unpinned third-party actions and `write-all`, medium otherwise.
+
+## 5. Done when
+
+- Every listed finding names a rule id or is labelled opinion.
+- The proposed YAML passes `actionlint` and `zizmor` (re-run them on the corrected file; include the result in Tools).
+- Every third-party `uses:` in the proposed YAML is a full SHA with a version comment, resolved with `scripts/pin-action.sh`.
+- Placeholders you introduced (secret names, environment names, registries) are listed for the user to confirm.
+
+## Why hard and opinion stay separate
+
+A reader can act on hard findings without agreeing with Bret's taste, and can adopt the opinions without an incident behind them. Merging the lists would let a naming nit sit next to a shell-injection hole at the same visual weight, and the reader would rightly distrust the whole report.

--- a/skills/github-actions-workflow-pro/references/security.md
+++ b/skills/github-actions-workflow-pro/references/security.md
@@ -1,0 +1,44 @@
+# Security reference
+
+The full rule set behind the security lines of the SKILL.md checklist, each with the reason it exists. Read this when granting permissions, adding or pinning a third-party action, adding a secret or cloud credential, meeting `pull_request_target`, checking Dependabot, or writing the security section of an audit. GitHub Actions is a high-value supply-chain target: a workflow runs arbitrary code with a token, so these are defaults, not add-ons.
+
+## Permissions: least-privilege
+
+- Start every workflow with `permissions: {}` at the top level, then grant per job. The token starts with nothing, and each job's block documents exactly what it can touch, so a compromised step inherits only that job's grants. Default token permissions vary by org and repo setting; the empty block makes the workflow independent of them.
+- `actions/checkout` needs `contents: read`, even under `permissions: {}`. A job that only calls an API and never checks out can stay at zero grants.
+- Look up each action's README for the permissions it needs before granting. When the README is silent and you are still unsure, ask the user about that specific grant rather than widening it. An unexplained `write` grant is how `write-all` creeps back in.
+- When you meet `permissions: write-all` (or a broad top-level `write`), enumerate what each job actually does and replace it with per-job grants. The rewrite is the finding, so show the before and after.
+
+## Third-party actions: pinned
+
+- Pin every action outside the user's or org's scope to a full commit SHA with the version as a trailing comment: `uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1`. Tags move; a SHA is immutable. The comment keeps the version readable for humans and lets Dependabot update the pin.
+- Choose a release that is at least 7 days old. Compromised releases are usually caught and yanked within days; the wait lets the ecosystem catch a bad one before this repo adopts it.
+- Run `scripts/pin-action.sh owner/repo` to do the lookup. It picks the newest release that passes the age rule, dereferences annotated tags, and prints the `uses:` value. Pass `@vX` to resolve a specific tag, `--line` for a paste-ready line, `--help` for the rest.
+- Same-owner actions and reusable workflows may use a tag or a SHA. A branch ref such as `@main` is the one form to replace: it moves on every push to that repo, so a compromise there runs here on the next commit with no release step between (gasa reports this at medium).
+- Dependabot keeps SHA pins current. If `.github/dependabot.yml` exists without a `github-actions` entry, or the entry lacks a daily schedule or a cooldown of at least 7 days, recommend:
+
+```yaml
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "daily"
+  cooldown:
+    default-days: 7
+  commit-message:
+    prefix: "[actions] "
+```
+
+  Without `cooldown`, Dependabot proposes the fresh SHA on release day and quietly undoes the 7-day rule.
+
+## Credentials: OIDC over static secrets
+
+- For cloud deploys and any tool that supports it, authenticate with GitHub OIDC federation: the job gets `id-token: write` and the cloud trusts the repo's identity. There is no long-lived key to leak, rotate, or find in a log. When a tool needs a secret and you are unsure whether it supports OIDC, offer to check its docs before adding the secret.
+- Scope each third-party secret to a GitHub repository environment and have the job declare `environment:`. The secret is then visible only to jobs that name that environment, and environment protection rules gate who can trigger them. zizmor flags secrets used outside an environment: <https://docs.zizmor.sh/audits/#secrets-outside-env>.
+- Pass secrets into the one step that uses them via `env:` and reference them as `$VAR` in `run:`. Print only derived, non-secret values (an image digest, a URL). Full `env` dumps and `set -x` in a step with secrets belong to debugging in a fork, not to a committed workflow.
+
+## Untrusted input: trusted context only
+
+- Put any `${{ github.event.* }}` value (PR title, branch name, issue body, commit message) into `env:` and reference it as `"$VAR"` inside `run:`. Interpolating it directly into the script is shell injection by anyone who can open a PR. zizmor's `template-injection` audit catches the direct form.
+- `pull_request` is the safe default for PRs: fork runs get a read-only token and no secrets.
+- `pull_request_target` runs the base branch's YAML with a write token and secrets, so it exists for private repos where a fork PR genuinely needs trusted context (labeling, commenting). When it must be used, keep untrusted code out of the privileged job: check out `github.event.pull_request.head.sha` only in a separate job with zero grants, and gate the privileged job on a maintainer label. In a public repo, use `pull_request` and move the privileged work to a `workflow_run` follow-up. gasa rates `pull_request_target` critical.
+- Adding `workflow_dispatch` or `repository_dispatch` widens who can start a privileged run, so it is a decision for the user: ask before adding either.

--- a/skills/github-actions-workflow-pro/references/speed.md
+++ b/skills/github-actions-workflow-pro/references/speed.md
@@ -1,0 +1,49 @@
+# Speed reference
+
+The rules behind the speed lines of the SKILL.md checklist, with the reason for each. Read this when the user reports slow CI, when adding a matrix, path filter, or cache, or when writing the speed section of an audit. Fast workflows get maintained; slow ones get ignored, so quick feedback is worth a few extra lines of YAML but never clever YAML.
+
+## Cancel superseded runs
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+A new push to the same PR or branch makes the running build stale; cancelling it frees the runner for the run that matters. Deploy and release workflows are the exception: cancelling a deploy mid-flight is worse than waiting, so give them their own group with `cancel-in-progress: false` (a queue) rather than sharing the CI group.
+
+## Order jobs cheap to expensive
+
+Lint, typecheck, and unit tests run first; build, integration, and deploy jobs declare `needs:` on them. A broken import fails in thirty seconds instead of after a ten-minute image build, and the expensive jobs never start on a red commit.
+
+## Cache through the setup action
+
+Use the cache the official setup action provides: `actions/setup-node` with `cache: npm` (or `pnpm`, `yarn`), `actions/setup-python` with `cache: pip`, `actions/setup-go` (caching on by default), and Buildx with `cache-from: type=gha` / `cache-to: type=gha,mode=max` for images. The setup action derives the cache key from the lockfile, so the key is right without hand-written `hashFiles` logic. Reach for `actions/cache` directly only when no setup action covers the tool.
+
+`type=gha` cache is scoped per branch by default: a PR from a new branch misses on its first build and falls through to the default branch's cache. That is expected, not a bug to fix.
+
+## Time-box jobs that can hang
+
+Set `timeout-minutes` on jobs that talk to the network, run integration suites, or deploy. The default is 360 minutes: a hung job burns six hours of runner time and, with concurrency on, blocks the next run in its group. Ten to thirty minutes covers most jobs; pick a value near twice the normal run time.
+
+## Path filters only when obviously correct
+
+On CI workflows, skip runs that touch only docs:
+
+```yaml
+on:
+  pull_request:
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+```
+
+Security, release, and deploy workflows stay unfiltered: a workflow that runs on "relevant" paths is a workflow that silently stops running when someone moves a file. Path-filtered jobs that are also required status checks block the PR forever, because a skipped workflow never reports; keep required checks unfiltered or add a no-op job that always reports.
+
+## Fan out only for confidence
+
+A matrix earns its cost when each cell tests something the others cannot: a supported OS, a runtime version the project promises to support, an architecture that ships. Cells with identical inputs are the same test paid for twice. Use `fail-fast: false` when the user wants every cell's result rather than the first failure, and `include:`/`exclude:` to trim cells that cannot happen.
+
+## Checkout depth
+
+`actions/checkout` fetches one commit by default, which is what CI needs. Release jobs that read tags (`docker/metadata-action` semver tags, changelog tools) need `fetch-depth: 0`; set it only in that job rather than everywhere.

--- a/skills/github-actions-workflow-pro/scripts/pin-action.sh
+++ b/skills/github-actions-workflow-pro/scripts/pin-action.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# pin-action.sh — resolve a GitHub Action (or reusable workflow) reference to a
+# full commit SHA, choosing the newest release that is at least MIN_AGE_DAYS old.
+#
+# Why the age rule: a compromised release is usually noticed and yanked within
+# days. Waiting before adopting a release lets the ecosystem catch it first.
+#
+# Requires: gh (authenticated), bash 4+. No jq binary needed — gh's --jq is used.
+set -euo pipefail
+
+MIN_AGE_DAYS=7
+ALLOW_FRESH=0
+LINE_OUTPUT=0
+
+usage() {
+  cat <<'EOF'
+Usage: pin-action.sh [options] owner/repo[/subpath][@ref]
+
+Resolve an action reference to `owner/repo[/subpath]@<full-sha> # <tag>`.
+
+Without @ref: pick the newest non-prerelease release published at least
+--min-age-days ago (default 7). Falls back to tags when the repo has no
+releases (age taken from the tag's commit date).
+
+With @ref: resolve exactly that tag. Still fails if it is younger than the
+minimum age unless --allow-fresh is passed.
+
+Options:
+  --min-age-days N   Minimum release age in days (default 7)
+  --allow-fresh      Accept a release younger than the minimum age
+  --line             Print a ready-to-paste `uses:` line instead of JSON
+  -h, --help         Show this help
+
+Output (JSON on stdout, diagnostics on stderr):
+  {"uses":"actions/checkout@<sha>","tag":"v7.0.1","comment":"# v7.0.1",
+   "published":"2026-07-20T15:10:05Z","age_days":36,"source":"release"}
+
+Exit codes:
+  0 resolved     2 bad arguments     3 repo or ref not found
+  4 no release old enough (use --allow-fresh or an older @ref)
+  5 gh missing or not authenticated
+
+Examples:
+  pin-action.sh actions/checkout
+  pin-action.sh --line docker/build-push-action
+  pin-action.sh github/codeql-action/upload-sarif@v3
+  pin-action.sh --min-age-days 14 actions/setup-node
+EOF
+}
+
+die() { echo "pin-action: $2" >&2; exit "$1"; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --min-age-days) [ $# -ge 2 ] || die 2 "--min-age-days needs a value"; MIN_AGE_DAYS="$2"; shift 2 ;;
+    --allow-fresh)  ALLOW_FRESH=1; shift ;;
+    --line)         LINE_OUTPUT=1; shift ;;
+    -h|--help)      usage; exit 0 ;;
+    -*)             die 2 "unknown option: $1 (see --help)" ;;
+    *)              break ;;
+  esac
+done
+[ $# -eq 1 ] || { usage >&2; exit 2; }
+[[ "$MIN_AGE_DAYS" =~ ^[0-9]+$ ]] || die 2 "--min-age-days must be an integer, got: $MIN_AGE_DAYS"
+
+command -v gh >/dev/null || die 5 "gh CLI not found; install it and run 'gh auth login'"
+gh auth status >/dev/null 2>&1 || die 5 "gh is not authenticated; run 'gh auth login'"
+
+# Parse owner/repo[/subpath][@ref]
+SPEC="$1"
+REF="${SPEC##*@}"; [ "$REF" = "$SPEC" ] && REF=""
+PATHPART="${SPEC%@*}"
+OWNER="${PATHPART%%/*}"
+REST="${PATHPART#*/}"
+REPO="${REST%%/*}"
+SUBPATH="${REST#"$REPO"}"; SUBPATH="${SUBPATH#/}"
+[ -n "$OWNER" ] && [ -n "$REPO" ] && [ "$OWNER" != "$PATHPART" ] || die 2 "expected owner/repo[/subpath][@ref], got: $SPEC"
+FULL="$OWNER/$REPO"
+MIN_AGE_SECONDS=$((MIN_AGE_DAYS * 86400))
+
+gh api "repos/$FULL" --jq .full_name >/dev/null 2>&1 || die 3 "repository not found or not accessible: $FULL"
+
+# tag_to_commit <tag> -> commit sha (derefs annotated tags)
+tag_to_commit() {
+  local tag="$1" type sha
+  read -r type sha < <(gh api "repos/$FULL/git/ref/tags/$tag" --jq '"\(.object.type) \(.object.sha)"' 2>/dev/null) \
+    || die 3 "tag not found: $FULL@$tag"
+  [ -n "$sha" ] || die 3 "tag not found: $FULL@$tag"
+  if [ "$type" = "tag" ]; then
+    sha=$(gh api "repos/$FULL/git/tags/$sha" --jq .object.sha)
+  fi
+  printf '%s\n' "$sha"
+}
+
+# commit_date <sha> -> ISO8601 committer date
+commit_date() { gh api "repos/$FULL/git/commits/$1" --jq .committer.date; }
+
+# age_seconds <iso8601> -> whole seconds since that instant (jq does the date math)
+age_seconds() { gh api /rate_limit --jq "(now - (\"$1\"|fromdateiso8601)) | floor"; }
+
+TAG="" PUBLISHED="" SOURCE=""
+if [ -n "$REF" ]; then
+  TAG="$REF"
+  # Prefer the release publish date; bare tags fall back to the commit date below.
+  # (gh prints the 404 body on stdout, so discard the output on failure.)
+  PUBLISHED=$(gh api "repos/$FULL/releases/tags/$TAG" --jq .published_at 2>/dev/null) || PUBLISHED=""
+  if [ -n "$PUBLISHED" ]; then SOURCE="release"; else SOURCE="tag"; fi
+else
+  # Newest non-draft, non-prerelease release at least MIN_AGE old.
+  read -r TAG PUBLISHED < <(gh api "repos/$FULL/releases?per_page=100" \
+    --jq "[.[] | select(.draft==false and .prerelease==false and ((now - (.published_at|fromdateiso8601)) >= $MIN_AGE_SECONDS))] | .[0] | select(.) | \"\(.tag_name) \(.published_at)\"" 2>/dev/null) || true
+  if [ -n "$TAG" ]; then
+    SOURCE="release"
+  else
+    # Either no releases at all, or every release is too fresh. Tell them apart.
+    NEWEST=$(gh api "repos/$FULL/releases?per_page=1" --jq '.[0] | select(.) | "\(.tag_name) \(.published_at)"' 2>/dev/null || true)
+    if [ -n "$NEWEST" ]; then
+      if [ "$ALLOW_FRESH" -eq 1 ]; then
+        read -r TAG PUBLISHED <<<"$NEWEST"; SOURCE="release"
+      else
+        die 4 "every release of $FULL is younger than $MIN_AGE_DAYS days (newest: $NEWEST); wait, pin an older @ref, or pass --allow-fresh"
+      fi
+    else
+      # Tags only: walk the newest few and take the first old enough.
+      SOURCE="tag"
+      while read -r t; do
+        [ -n "$t" ] || continue
+        d=$(commit_date "$(tag_to_commit "$t")")
+        if [ "$(age_seconds "$d")" -ge "$MIN_AGE_SECONDS" ] || [ "$ALLOW_FRESH" -eq 1 ]; then
+          TAG="$t"; PUBLISHED="$d"; break
+        fi
+      done < <(gh api "repos/$FULL/tags?per_page=10" --jq '.[].name')
+      [ -n "$TAG" ] || die 4 "no tag of $FULL is at least $MIN_AGE_DAYS days old (checked newest 10)"
+    fi
+  fi
+fi
+
+SHA=$(tag_to_commit "$TAG")
+
+# A moving major tag (v4) points at some exact release (v4.2.1). Prefer the most
+# specific tag name on the same commit so the comment says which version was pinned.
+SPECIFIC=$(gh api "repos/$FULL/tags?per_page=100" \
+  --jq "[.[] | select(.commit.sha==\"$SHA\") | .name] | sort_by(length) | last // empty" 2>/dev/null) || SPECIFIC=""
+if [ -n "$SPECIFIC" ] && [ "$SPECIFIC" != "$TAG" ]; then
+  TAG="$SPECIFIC"
+  if [ -z "$PUBLISHED" ]; then
+    PUBLISHED=$(gh api "repos/$FULL/releases/tags/$TAG" --jq .published_at 2>/dev/null) || PUBLISHED=""
+    [ -n "$PUBLISHED" ] && SOURCE="release"
+  fi
+fi
+
+[ -n "$PUBLISHED" ] || PUBLISHED=$(commit_date "$SHA")
+AGE_DAYS=$(( $(age_seconds "$PUBLISHED") / 86400 ))
+
+if [ -n "$REF" ] && [ "$AGE_DAYS" -lt "$MIN_AGE_DAYS" ] && [ "$ALLOW_FRESH" -eq 0 ]; then
+  die 4 "$FULL@$TAG is only $AGE_DAYS days old (minimum $MIN_AGE_DAYS); pick an older ref or pass --allow-fresh"
+fi
+
+USES="$FULL${SUBPATH:+/$SUBPATH}@$SHA"
+if [ "$LINE_OUTPUT" -eq 1 ]; then
+  printf 'uses: %s # %s\n' "$USES" "$TAG"
+else
+  printf '{"uses":"%s","tag":"%s","comment":"# %s","published":"%s","age_days":%s,"source":"%s"}\n' \
+    "$USES" "$TAG" "$TAG" "$PUBLISHED" "$AGE_DAYS" "$SOURCE"
+fi


### PR DESCRIPTION
Part 2 of 11 in stack #13 (`gha-skill/references`, base `gha-skill/evals-fix`). Review bottom-up; each layer was diff-reviewed before its commit.

## Changes
- **Add security, speed, and audit references plus pin-action.sh**

## Verification
- `make lint` clean (markdownlint, prettier, yamllint, shellcheck, py_compile, actionlint, zizmor, poutine, pinact).
- `make lint` clean at the layer's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yRNwbvpf198fiYZHgkt1w