### PR TITLE
Rewrite SKILL.md as router plus checklist; fix references and pin-action from manual runs

### DIFF
--- a/skills/github-actions-workflow-pro/SKILL.md
+++ b/skills/github-actions-workflow-pro/SKILL.md
@@ -1,101 +1,69 @@
 ---
 name: github-actions-workflow-pro
-description: Create, edit, review, and harden GitHub Actions workflows using Bret Fisher's strongly opinionated DevOps rules. Use this skill whenever the user asks about GitHub Actions, GHA, workflow YAML, CI/CD pipelines, Docker image publishing, workflow security, action pinning, build caching, matrix builds, release automation, or `.github/workflows/*` files, even if they only ask for a small workflow change. This also compliments the "gasa" CLI tool which audits GitHub Actions workflows for security and best practices.
+description: Create, edit, audit, and speed up GitHub Actions workflows using Bret Fisher's opinionated DevOps rules. Use it when the user asks to create a workflow or CI/CD pipeline, edit or add a job to an existing `.github/workflows/*` file (even a one-line change), review or harden a workflow for security, speed up slow CI, publish a container image from CI, automate releases, or mentions GitHub Actions, GHA, action pinning, or findings from gasa, zizmor, or actionlint. Not for local linter setup (super-linting) or Dockerfile authoring (docker-pro).
 ---
 
 # GitHub Actions Workflow Rules
 
-Use this skill when creating, editing, reviewing, or troubleshooting GitHub Actions workflows. Be strongly opinionated: apply these defaults proactively unless the repository has clear conflicting conventions or the user explicitly asks for a different tradeoff.
+Apply these defaults proactively to every workflow you touch, unless the repository has a clear conflicting convention or the user asks for a different tradeoff. The rules exist because a workflow runs arbitrary code with a token: security is built in from the first line, and speed is what keeps a workflow maintained.
 
 ## Working Style
 
-1. Inspect existing workflow files before editing so new changes match repository naming, trigger, and secret conventions.
-2. Prefer the smallest correct workflow change, but do not preserve insecure or wasteful patterns when touching nearby code.
-4. Validate edited workflow YAML where practical with available tooling. Always run `actionlint` if it's installed. Always run `zizmor` if it's installed. If any tools are unavailable, say that explicitly and suggest it as the preferred linter. Do not install any tools that are not available on the user's system, only recommend them.
-5. Never invent secret names, environment names, package names, or cloud roles as facts. Use placeholders only when the repo does not reveal them, and call those out.
+1. Inspect existing workflow files before editing so new changes match the repository's naming, trigger, and secret conventions.
+2. Prefer the smallest correct change, and fix insecure or wasteful patterns in the code you are already touching.
+3. Facts are yours to find (an action's SHA, its required permissions, whether a tool supports OIDC). Decisions are the user's (adding a manual trigger, choosing a registry, creating an environment): put each one to them and wait.
+4. Use placeholders for secret names, environment names, package names, and cloud roles the repo does not reveal, and list every placeholder when you hand back.
 
-## Security Defaults
+## Building a workflow
 
-GitHub Actions is a high-value supply-chain target, so security defaults should be built into every workflow rather than added later.
+- Ask only about decisions the repo cannot answer: deploy target, registry, whether a needed secret already exists. Everything else you infer from the repo: the runtime version comes from its version file (`.nvmrc`, `.python-version`, `go.mod`) or `engines`, the lint and test commands from its scripts.
+- Use conventional filenames: `ci.yml`, `docker.yml`, `release.yml`, `deploy.yml`; `call-*.yaml` and `reusable-*.yaml` for reusable workflows.
+- Run `scripts/pin-action.sh --line owner/repo` for every third-party `uses:` (see **pinned** below); `--help` lists the rest.
+- For a Docker build workflow, or a lint workflow in a repo with no linter of its own, offer a reusable workflow before writing a bespoke one and ask whether the user already has one: Bret's are <https://github.com/BretFisher/docker-build-workflow> and <https://github.com/BretFisher/super-linter-workflow>. A repo that already defines `npm run lint` or equivalent runs that.
 
-- Set explicit top-level none permissions with `permissions: {}` for all workflow files. Then each job should only set explicit read or write permissions. Jobs will need at least `contents: read` if there is a `actions/checkout` step.
-- When in doubt about permissions, research each steps action for the expected permissions. If you are still not confident, ask the user for clarification on each permission grant.
-- Avoid broad `write-all` permissions.
-- When adding a third-party action, always pin to the full commit SHAs when the action is outside the user or orgs scope. Always look up the action's repo on github.com and get the official latest released tag that is at least 7 days old (to avoid supply chain attacks) and then grab the sha hash of that tag to add to the workflow in the format `actions/checkout@<full-sha> # vX.Y.Z`.
-- If a Dependabot config file exists at `.github/dependabot.yml` but there is not a `package-ecosystem: "github-actions"` entry, or it's missing the daily schedule or the cooldown of 7 (or more) days,recommend this YAML snippet to enable GitHub Actions updates:
+## Auditing an existing workflow
 
-```yaml
-- package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
-    commit-message:
-      prefix: "[actions] "
-```
+When the user hands you workflows to review, harden, secure, or speed up, or asks what is wrong with their CI, read `references/audit.md` and follow it. It runs the tools first (`actionlint`, `zizmor`, `gasa`), then sorts findings into hard, speed, and opinion, and ends in a fixed report shape.
 
-- Prefer GitHub OIDC federation for cloud deployments and other CI/CD tooling instead of long-lived credentials. If in doubt, ask user if they'd like to search for OIDC support in a tool that needs a secret.
-- Do not print secrets, tokens, or full environment dumps.
-- Avoid `pull_request_target` unless the workflow requires trusted context for forked PRs; if used, do not check out untrusted PR code before privileged operations. Never use `pull_request_target` for public repositories.
-- Recommend the user create a GitHub repository environment any time a 3rd party secret is needed in the repository for a step. This will improve the security posture of the repository by isolating secrets to specific environments. See the zizmor rule for more info: https://docs.zizmor.sh/audits/#secrets-outside-env
-- Always ask before adding events for manual dispatch or remotely triggered, because they may add security risks.
+## Checklist
 
-## Fast CI Defaults
+Every workflow you create or edit meets these. The linked reference carries the full rule and its reason; read it when a line needs more than the summary.
 
-Fast workflows get maintained; slow workflows get ignored. Optimize for quick feedback without making YAML clever.
+- `permissions: {}` at the top level, then **least-privilege** grants per job. `actions/checkout` still needs `contents: read`, and sets `persist-credentials: false` unless a later step pushes with the token. → `references/security.md`
+- Every third-party `uses:` is **pinned** to a full commit SHA with a `# vX.Y.Z` comment, from a release at least 7 days old. Same-owner refs may use a tag; a branch ref like `@main` gets replaced. → `references/security.md`
+- Cloud credentials come from OIDC (`id-token: write`), third-party secrets live in a repository environment the job names, and `${{ github.event.* }}` values reach `run:` only through `env:`. → `references/security.md`
+- `pull_request` for PR triggers. `pull_request_target` appears only in a private repo with the untrusted checkout isolated in its own zero-grant job, and never in a public one. → `references/security.md`
+- If `.github/dependabot.yml` exists, it has a `github-actions` entry with a daily schedule and a 7-day cooldown; recommend the snippet when it is missing. → `references/security.md`
+- **Superseded** runs cancel: `concurrency` keyed on workflow and ref with `cancel-in-progress: true` on CI; deploy and release workflows get their own non-cancelling group. → `references/speed.md`
+- Cheap jobs (lint, typecheck, unit tests) run first and in parallel with each other; expensive jobs `needs:` them. → `references/speed.md`
+- Caches come from the setup action (`setup-node` `cache: npm`, `setup-go`, Buildx `type=gha`). `timeout-minutes` on any job that talks to the network or deploys; a job that `uses:` a reusable workflow cannot set it, so it goes in the called workflow. → `references/speed.md`
+- New CI workflows ship without path filters; add one later only when it is obviously correct and the workflow is not a required check. Security, release, and deploy workflows stay unfiltered. → `references/speed.md`
+- Manual and remote triggers (`workflow_dispatch`, `repository_dispatch`) are added only after the user says yes.
 
-- Use `concurrency` for branch and PR workflows so superseded runs cancel:
+## Maintainable YAML
 
-```yaml
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-```
+- Friendly `name:` values with capitals and spaces: workflow 1–3 words, job up to 5, step up to 10. Two test jobs need names that tell them apart. Match the style of the repo's other workflows.
+- Triggers stay explicit: CI on `pull_request` and `push` to the default branch; releases on tags, releases, or manual dispatch (after asking).
+- Multi-line Bash steps start with `set -euo pipefail`; prefer several clear lines over one dense one.
+- Comments mark security boundaries, non-obvious triggers, and deployment gates. YAML keys explain themselves.
+- Reusable workflows earn their indirection when several workflows or repositories share stable behavior. One workflow stays inline.
 
-- Put cheap validation jobs before expensive build or deploy jobs.
-- Use package-manager caching through official setup actions when available, such as `setup-node` with `cache: npm`, `setup-go` with built-in cache, or Docker Buildx cache for images.
-- Prefer path filters only when they are obviously correct. Do not skip security or release workflows just because source paths did not change.
-- Use matrices for genuinely independent version/platform coverage. Avoid matrix fanout that does not increase confidence.
-- Add timeouts to jobs that could hang, especially integration tests and deployment jobs.
-- Scope file paths and/or file types of events in PRs so jobs only run on relevant files. Avoid running builds or programming tests if only markdown or docs changed.
+## Container images
 
-## Maintainable YAML Defaults
+Publish images on **trusted refs** only (default branch, tags, releases); PRs build without pushing.
 
-Readable workflows are easier to audit and easier to fix during incidents.
+- `docker/setup-buildx-action`, then `docker/metadata-action` for tags and labels, then `docker/build-push-action`. On a PR, `metadata-action` yields `pr-N`, not a semver tag, which is what you want.
+- `ghcr.io` unless the repo names another registry. `packages: write` goes only to the publishing job.
+- `cache-from: type=gha` and `cache-to: type=gha,mode=max`. `provenance: true` and `sbom: true` when publishing.
 
-- Use descriptive workflow, job, and step "friendly" names (YAML `name:` values) that use capitalization and limit dashes, underscores, or camelCase. They should be human friendly. Keep workflow names very short, with only 1 to 3 words. Job names should be 1 to 5 words at most. Step names can be up to 10 words. Consider the friendly names of other workflows in the repository when choosing names that are clear and concise. e.g. if there are two test jobs, they will need more detailed names.
-- Keep triggers explicit and predictable. For CI, normally use `pull_request` and `push` to the default branch. For releases, use tags, releases, or manual dispatch as appropriate.
-- Prefer clear shell steps over dense one-liners. Use `set -euo pipefail` for multi-line Bash steps.
-- Use comments sparingly for security boundaries, non-obvious triggers, or deployment gates. Avoid comments that merely restate YAML keys.
-- Prefer reusable workflows only when multiple repositories or several workflows truly share stable behavior. Do not introduce indirection for a single workflow.
-- If creating a new linting or docker build workflow, suggest using a reusable workflow and ask user if they have an existing reusable workflow repository. For a docker reusable workflow, suggest using https://github.com/BretFisher/docker-build-workflow and for linting, suggest using super-linter with this example of a reusable workflow https://github.com/BretFisher/super-linter-workflow
-- Use stable, conventional filenames: `ci.yml`, `docker.yml`, `release.yml`, `deploy.yml`. For reusable workflows, use `call-*.yaml` and `reusable-*.yaml` filenames to clarify their purpose.
+## Validate
 
-## Docker And DevOps Defaults
+Run `actionlint` and then `GH_TOKEN=$(gh auth token) zizmor` on every file you edited (zizmor stays offline without the token); fix what they report and run again until both are clean. `gasa` audits a pushed repository through the API, so it belongs to the audit path, not to a local edit. Name any tool that is not installed and recommend it; do not install it. Hand back only when the validators are clean or reported absent.
 
-For container builds, prefer modern BuildKit-based workflows that produce traceable images without wasting rebuild time.
+## Done when
 
-- Use `docker/setup-buildx-action` before image builds.
-- Use `docker/metadata-action` for tags and labels rather than hand-writing ad hoc tag logic.
-- Use `docker/build-push-action` for builds and pushes.
-- Use GitHub Container Registry (`ghcr.io`) by default when the repo does not specify another registry.
-- Grant `packages: write` only to the image publishing job.
-- Use Buildx GitHub Actions cache unless the repo has a better remote cache:
-
-```yaml
-cache-from: type=gha
-cache-to: type=gha,mode=max
-```
-
-- For PRs, build without pushing. For default branch, tags, or releases, push when appropriate.
-- Enable provenance and SBOM when publishing images:
-
-```yaml
-provenance: true
-sbom: true
-```
-
-## gasa - GitHub Actions Security Audit
-
-`gasa` is a CLI tool that audits GitHub Actions workflows and repository admin settings for security and best practices.
+- [ ] `actionlint` and `zizmor` clean on every edited file, or reported absent by name
+- [ ] Every job has a `permissions:` block and the workflow starts with `permissions: {}`
+- [ ] Every third-party `uses:` is a full SHA with a version comment
+- [ ] Every placeholder is listed for the user to confirm
+- [ ] The hand-back states the reason for each opinionated default you applied, in one line each

--- a/skills/github-actions-workflow-pro/references/audit.md
+++ b/skills/github-actions-workflow-pro/references/audit.md
@@ -7,43 +7,56 @@ Read this when the user hands you one or more workflows to review, harden, secur
 Before reading any YAML:
 
 - Locate the files: `.github/workflows/*.yml` and `*.yaml`, or the file the user pointed at. No files is a finding in itself: say so and stop.
-- Check the tools: `command -v actionlint zizmor gasa gh`. Report by name anything missing and continue with what is present. Recommend the missing tool at the end, do not install it.
-- `gasa` scans a repository, not a file, and needs `gh auth status` to pass. If auth fails, run the file-level tools only and say gasa was skipped.
+- Check the tools: `command -v actionlint shellcheck zizmor gasa gh`. Report by name anything missing and continue with what is present. Recommend the missing tool at the end, do not install it. `actionlint` runs shellcheck on `run:` blocks only when shellcheck is installed, so a clean actionlint without shellcheck says less than it looks.
+- `gasa` scans a repository through the GitHub API (it infers `owner/repo` from the remote when run inside a clone) and needs `gh auth status` to pass. If auth fails or the repo has no remote, run the file-level tools only and say gasa was skipped.
+- If the user says the workflow is failing, or `gh run list` shows red, read the failed run log (`gh run view <id> --log-failed`) before reading YAML. A broken workflow is the top finding regardless of what the linters say.
 
 ## 2. Run the tools, then read the YAML
 
 The tools are the source of truth for hard findings; run them first so your own reading fills gaps instead of duplicating rules the tools already enforce.
 
 ```bash
-actionlint -format '{{json .}}' .github/workflows/*.y*ml
-zizmor --format json --offline .github/workflows/
-gasa run --format json --category workflows            # repo-level; add settings,updates if gh auth passes and the user wants admin checks
+actionlint .github/workflows/*.y*ml
+GH_TOKEN=$(gh auth token) zizmor --format json .github/workflows/      # online audits need the token; zizmor stays offline without it
+gasa run --format json                                                 # all categories; read-only, so a security audit runs settings too
+gh run list --workflow <file> --limit 10 --json conclusion,startedAt,updatedAt \
+  --jq '.[] | "\(.conclusion) \((.updatedAt|fromdateiso8601) - (.startedAt|fromdateiso8601))s"'
 ```
 
 - `actionlint`: syntax, expression types, shellcheck on `run:` blocks, unknown runner labels.
-- `zizmor`: template injection, secrets outside environments, dangerous triggers, unpinned uses, excessive permissions. `--offline` skips audits that need the API; drop it when `gh auth status` passes and you want impostor-commit and stale-ref checks.
-- `gasa`: pinning, permissions, `pull_request_target`, Dependabot coverage, and (with `settings`) repo admin settings such as default token permissions and fork-PR approval. Run `gasa rules` for the current list and each rule's doc URL rather than restating them here.
+- `zizmor`: template injection, secrets outside environments, dangerous triggers, unpinned uses, excessive permissions, checkout credential persistence. A second pass with `--persona pedantic` surfaces style-grade items; those feed the Opinions section, never Hard.
+- `gasa`: pinning, permissions, `pull_request_target`, Dependabot coverage, and repository settings (default token permissions, fork-PR approval, allowed-actions policy). Each finding carries its own `doc_url`; run `gasa rules` only when one does not.
+- Run history gives you failure rate and duration, which no linter sees. Quantify speed findings from it.
 
-Then read each workflow once, top to bottom, against `references/security.md` and `references/speed.md`. Note anything the tools cannot see: a deploy job sharing a cancel-in-progress group with CI, a matrix of identical cells, a `write` grant no step uses, a release workflow with a path filter.
+Then read each workflow once, top to bottom, against `references/security.md` and `references/speed.md`. Note anything the tools cannot see: a deploy job sharing a cancel-in-progress group with CI, a matrix of identical cells, a `write` grant no step uses, a release workflow with a path filter, a reusable workflow whose inputs cannot express what its callers need.
 
-## 3. Sort findings into hard and opinion
+## 3. Sort findings
 
-- **Hard**: a tool rule fired, or the YAML violates a rule in `security.md` that has a concrete failure mode (injection, unpinned third-party action, `write-all`, `pull_request_target` in a public repo, static cloud keys). Cite the rule id (`zizmor: template-injection`, `gasa: workflows/action-version-pinning`, `security.md: pinned`) and `file:line`.
-- **Speed**: a rule from `speed.md` not applied where it would obviously help. Quantify when you can ("build job has no timeout; last run was 41 min").
-- **Opinion**: Bret's conventions with no failure mode attached: friendly names, filename conventions, `ghcr.io` default, reusable-workflow suggestions. Label each "opinion". A convention the repo already follows consistently overrides the opinion; say so instead of proposing churn.
+- **Correctness**: the workflow does not do what it claims. Failing runs, a filter that never matches, a step that breaks on multi-line input, a reusable workflow that always pushes. No rule id; severity high. These come from run logs and reading, not from linters, and they go first because a workflow that does not run has no security or speed to audit.
+- **Hard**: a tool rule fired, or the YAML violates a rule in `security.md` that has a concrete failure mode (injection, unpinned third-party action, `write-all`, `pull_request_target` in a public repo, static cloud keys). Cite the rule id (`zizmor: template-injection`, `gasa: workflows/action-version-pinning`, `security.md: pinned`) and `file:line`. gasa settings findings go here too, with their rule id.
+- **Speed**: a rule from `speed.md` not applied where it would obviously help. Quantify from run history ("build job has no timeout; last 10 runs took 38–41 min").
+- **Opinion**: Bret's conventions with no failure mode attached: friendly names, filename conventions, `ghcr.io` default, reusable-workflow suggestions, zizmor pedantic items. Label each "opinion". A convention the repo already follows consistently overrides the opinion; say so instead of proposing churn.
 
-Skip anything a tool already enforces and reports cleanly; the reader has the tool output. Skip anything the repo has explicitly configured away (a `.gasa.yml` ignore, a `# zizmor: ignore[...]` comment) unless the ignore itself looks wrong.
+Two precedence rules:
+
+- A suppression in one tool does not cancel a finding from another. A `# zizmor: ignore[unpinned-uses]` comment silences zizmor; if gasa still fires on that line, report it and quote the ignore's stated reason so the reader can judge whether it covers this failure mode.
+- A hard finding the repo has consciously accepted (documented in a comment, `dependabot.yml`, or `.gasa.yml`) is still reported. State the repo's reason next to it and hand the decision back; deciding is the user's job, hiding the finding is not yours.
+
+Skip anything a tool already enforces and reports cleanly; the reader has the tool output.
 
 ## 4. Report
 
 Use this shape. Empty sections stay in with "none".
 
 ```markdown
+## Correctness
+- high <file>:<line> — <what is broken, with the evidence: run id, log line>. Fix: <the change>.
+
 ## Hard findings
 - <severity> `<rule id>` <file>:<line> — <what is wrong in one line>. Fix: <the change>.
 
 ## Speed
-- <file>:<line> — <what is slow and why>. Fix: <the change>.
+- <file>:<line> — <what is slow and why, with numbers>. Fix: <the change>.
 
 ## Opinions
 - <file> — <convention>, opinion. <one-line why it helps>.
@@ -52,18 +65,22 @@ Use this shape. Empty sections stay in with "none".
 <unified diff, or the full corrected file when most lines change>
 
 ## Tools
-actionlint <version|absent>, zizmor <version|absent>, gasa <version|absent|skipped: reason>
+actionlint <version|absent>, shellcheck <version|absent>, zizmor <version|absent> (<online|offline>), gasa <version|absent|skipped: reason>
 ```
 
-Severity comes from the tool that reported it; for `security.md` rules use critical for injection and `pull_request_target` in public repos, high for unpinned third-party actions and `write-all`, medium otherwise.
+Severity comes from the tool that reported it. For `security.md` rules without a tool hit: critical for injection and `pull_request_target` in a public repo, high for an unpinned third-party action or `write-all`, medium for a same-owner branch ref (matches gasa) and everything else.
+
+When the user asked you not to edit, copy the workflows to a scratch directory, apply the diff there, and validate the copy.
+
+Ordering matters when settings findings and workflow findings interact: turning on "require SHA pinning" in repo settings before the `@main` ref is fixed stops the workflow from running. Say which fix goes first.
 
 ## 5. Done when
 
-- Every listed finding names a rule id or is labelled opinion.
-- The proposed YAML passes `actionlint` and `zizmor` (re-run them on the corrected file; include the result in Tools).
-- Every third-party `uses:` in the proposed YAML is a full SHA with a version comment, resolved with `scripts/pin-action.sh`.
+- Every listed finding names a rule id, is under Correctness with its evidence, or is labelled opinion.
+- The proposed YAML passes `actionlint` and `zizmor` (re-run them on the corrected copy; include the result in Tools).
+- Every third-party `uses:` in the proposed YAML is a full SHA with a version comment from `scripts/pin-action.sh`. For a repo with no tags the script pins the default branch HEAD and comments `# main YYYY-MM-DD`; say in the report that Dependabot cannot bump that pin.
 - Placeholders you introduced (secret names, environment names, registries) are listed for the user to confirm.
 
-## Why hard and opinion stay separate
+## Why the sections stay separate
 
-A reader can act on hard findings without agreeing with Bret's taste, and can adopt the opinions without an incident behind them. Merging the lists would let a naming nit sit next to a shell-injection hole at the same visual weight, and the reader would rightly distrust the whole report.
+A reader can act on hard findings without agreeing with Bret's taste, adopt the opinions without an incident behind them, and fix a broken workflow before caring about either. Merging the lists would let a naming nit sit next to a shell-injection hole at the same visual weight, and the reader would rightly distrust the whole report.

--- a/skills/github-actions-workflow-pro/references/security.md
+++ b/skills/github-actions-workflow-pro/references/security.md
@@ -6,6 +6,7 @@ The full rule set behind the security lines of the SKILL.md checklist, each with
 
 - Start every workflow with `permissions: {}` at the top level, then grant per job. The token starts with nothing, and each job's block documents exactly what it can touch, so a compromised step inherits only that job's grants. Default token permissions vary by org and repo setting; the empty block makes the workflow independent of them.
 - `actions/checkout` needs `contents: read`, even under `permissions: {}`. A job that only calls an API and never checks out can stay at zero grants.
+- `actions/checkout` sets `persist-credentials: false` unless a later step in that job pushes or pulls with the token. By default it writes the token into `.git/config`, where any later step, cached artifact, or uploaded workspace can read it. zizmor reports the default as `artipacked`, so leaving it out costs a validate-and-fix cycle every time.
 - Look up each action's README for the permissions it needs before granting. When the README is silent and you are still unsure, ask the user about that specific grant rather than widening it. An unexplained `write` grant is how `write-all` creeps back in.
 - When you meet `permissions: write-all` (or a broad top-level `write`), enumerate what each job actually does and replace it with per-job grants. The rewrite is the finding, so show the before and after.
 
@@ -15,17 +16,20 @@ The full rule set behind the security lines of the SKILL.md checklist, each with
 - Choose a release that is at least 7 days old. Compromised releases are usually caught and yanked within days; the wait lets the ecosystem catch a bad one before this repo adopts it.
 - Run `scripts/pin-action.sh owner/repo` to do the lookup. It picks the newest release that passes the age rule, dereferences annotated tags, and prints the `uses:` value. Pass `@vX` to resolve a specific tag, `--line` for a paste-ready line, `--help` for the rest.
 - Same-owner actions and reusable workflows may use a tag or a SHA. A branch ref such as `@main` is the one form to replace: it moves on every push to that repo, so a compromise there runs here on the next commit with no release step between (gasa reports this at medium).
-- Dependabot keeps SHA pins current. If `.github/dependabot.yml` exists without a `github-actions` entry, or the entry lacks a daily schedule or a cooldown of at least 7 days, recommend:
+- When the same-owner repo has no tags or releases, `pin-action.sh` pins the default branch HEAD and comments `# main YYYY-MM-DD`. That makes the ref immutable but leaves Dependabot unable to bump it, so the durable fix is for the owner to tag releases; put that choice to the user.
+- Dependabot keeps SHA pins current. If `.github/dependabot.yml` exists without a `github-actions` entry, or the entry lacks a daily schedule or a cooldown of at least 7 days, recommend the entry below (wrap it in `version: 2` / `updates:` when the file does not exist yet):
 
 ```yaml
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "daily"
-  cooldown:
-    default-days: 7
-  commit-message:
-    prefix: "[actions] "
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "[actions] "
 ```
 
   Without `cooldown`, Dependabot proposes the fresh SHA on release day and quietly undoes the 7-day rule.

--- a/skills/github-actions-workflow-pro/references/speed.md
+++ b/skills/github-actions-workflow-pro/references/speed.md
@@ -14,7 +14,7 @@ A new push to the same PR or branch makes the running build stale; cancelling it
 
 ## Order jobs cheap to expensive
 
-Lint, typecheck, and unit tests run first; build, integration, and deploy jobs declare `needs:` on them. A broken import fails in thirty seconds instead of after a ten-minute image build, and the expensive jobs never start on a red commit.
+Lint, typecheck, and unit tests run first; build, integration, and deploy jobs declare `needs:` on them. A broken import fails in thirty seconds instead of after a ten-minute image build, and the expensive jobs never start on a red commit. Cheap jobs that do not depend on each other run in parallel; `needs:` is for a job that would waste runner time on a red predecessor, not for ordering the fast ones.
 
 ## Cache through the setup action
 
@@ -25,6 +25,8 @@ Use the cache the official setup action provides: `actions/setup-node` with `cac
 ## Time-box jobs that can hang
 
 Set `timeout-minutes` on jobs that talk to the network, run integration suites, or deploy. The default is 360 minutes: a hung job burns six hours of runner time and, with concurrency on, blocks the next run in its group. Ten to thirty minutes covers most jobs; pick a value near twice the normal run time.
+
+A job that `uses:` a reusable workflow cannot set `timeout-minutes` (GitHub rejects it), so the timeout belongs in the called workflow's jobs. A reusable workflow with unknown callers hardcodes a generous value or exposes `timeout-minutes` as an input.
 
 ## Path filters only when obviously correct
 
@@ -38,7 +40,7 @@ on:
       - "docs/**"
 ```
 
-Security, release, and deploy workflows stay unfiltered: a workflow that runs on "relevant" paths is a workflow that silently stops running when someone moves a file. Path-filtered jobs that are also required status checks block the PR forever, because a skipped workflow never reports; keep required checks unfiltered or add a no-op job that always reports.
+Security, release, and deploy workflows stay unfiltered: a workflow that runs on "relevant" paths is a workflow that silently stops running when someone moves a file. Path-filtered jobs that are also required status checks block the PR forever, because a skipped workflow never reports; keep required checks unfiltered or add a no-op job that always reports. A new CI workflow is the likeliest future required check, so ship it unfiltered and offer the filter as a follow-up once the user knows which checks are required.
 
 ## Fan out only for confidence
 

--- a/skills/github-actions-workflow-pro/scripts/pin-action.sh
+++ b/skills/github-actions-workflow-pro/scripts/pin-action.sh
@@ -18,9 +18,10 @@ Usage: pin-action.sh [options] owner/repo[/subpath][@ref]
 
 Resolve an action reference to `owner/repo[/subpath]@<full-sha> # <tag>`.
 
-Without @ref: pick the newest non-prerelease release published at least
---min-age-days ago (default 7). Falls back to tags when the repo has no
-releases (age taken from the tag's commit date).
+Without @ref: pick the highest semver release (vX.Y[.Z], no suffix) published
+at least --min-age-days ago (default 7). Falls back to semver tags when the
+repo has no releases, and to the default branch HEAD when it has neither
+(source "branch", comment "# main YYYY-MM-DD", warning on stderr).
 
 With @ref: resolve exactly that tag. Still fails if it is younger than the
 minimum age unless --allow-fresh is passed.
@@ -37,7 +38,7 @@ Output (JSON on stdout, diagnostics on stderr):
 
 Exit codes:
   0 resolved     2 bad arguments     3 repo or ref not found
-  4 no release old enough (use --allow-fresh or an older @ref)
+  4 every release or tag is too fresh (use --allow-fresh or an older @ref)
   5 gh missing or not authenticated
 
 Examples:
@@ -106,14 +107,19 @@ if [ -n "$REF" ]; then
   PUBLISHED=$(gh api "repos/$FULL/releases/tags/$TAG" --jq .published_at 2>/dev/null) || PUBLISHED=""
   if [ -n "$PUBLISHED" ]; then SOURCE="release"; else SOURCE="tag"; fi
 else
-  # Newest non-draft, non-prerelease release at least MIN_AGE old.
+  # Highest semver release (not newest by date: backports like v3.1.0-node20 are
+  # published after v8.x) among non-draft, non-prerelease releases at least MIN_AGE old.
+  # Only plain vX.Y[.Z] tags count; suffixed tags are backports or previews.
+  SEMVER_FILTER='select(.tag_name | test("^v?[0-9]+\\.[0-9]+(\\.[0-9]+)?$"))'
+  SEMVER_KEY='(.tag_name | ltrimstr("v") | split(".") | map(tonumber))'
   read -r TAG PUBLISHED < <(gh api "repos/$FULL/releases?per_page=100" \
-    --jq "[.[] | select(.draft==false and .prerelease==false and ((now - (.published_at|fromdateiso8601)) >= $MIN_AGE_SECONDS))] | .[0] | select(.) | \"\(.tag_name) \(.published_at)\"" 2>/dev/null) || true
+    --jq "[.[] | select(.draft==false and .prerelease==false) | $SEMVER_FILTER | select((now - (.published_at|fromdateiso8601)) >= $MIN_AGE_SECONDS)] | max_by($SEMVER_KEY) | select(.) | \"\(.tag_name) \(.published_at)\"" 2>/dev/null) || true
   if [ -n "$TAG" ]; then
     SOURCE="release"
   else
-    # Either no releases at all, or every release is too fresh. Tell them apart.
-    NEWEST=$(gh api "repos/$FULL/releases?per_page=1" --jq '.[0] | select(.) | "\(.tag_name) \(.published_at)"' 2>/dev/null || true)
+    # No eligible release. Either every semver release is too fresh, or there are none.
+    NEWEST=$(gh api "repos/$FULL/releases?per_page=100" \
+      --jq "[.[] | select(.draft==false and .prerelease==false) | $SEMVER_FILTER] | max_by($SEMVER_KEY) | select(.) | \"\(.tag_name) \(.published_at)\"" 2>/dev/null) || NEWEST=""
     if [ -n "$NEWEST" ]; then
       if [ "$ALLOW_FRESH" -eq 1 ]; then
         read -r TAG PUBLISHED <<<"$NEWEST"; SOURCE="release"
@@ -121,7 +127,7 @@ else
         die 4 "every release of $FULL is younger than $MIN_AGE_DAYS days (newest: $NEWEST); wait, pin an older @ref, or pass --allow-fresh"
       fi
     else
-      # Tags only: walk the newest few and take the first old enough.
+      # Tags without releases: highest semver tag whose commit is old enough.
       SOURCE="tag"
       while read -r t; do
         [ -n "$t" ] || continue
@@ -129,17 +135,32 @@ else
         if [ "$(age_seconds "$d")" -ge "$MIN_AGE_SECONDS" ] || [ "$ALLOW_FRESH" -eq 1 ]; then
           TAG="$t"; PUBLISHED="$d"; break
         fi
-      done < <(gh api "repos/$FULL/tags?per_page=10" --jq '.[].name')
-      [ -n "$TAG" ] || die 4 "no tag of $FULL is at least $MIN_AGE_DAYS days old (checked newest 10)"
+      done < <(gh api "repos/$FULL/tags?per_page=100" \
+        --jq "[.[] | select(.name | test(\"^v?[0-9]+\\\\.[0-9]+(\\\\.[0-9]+)?$\"))] | sort_by(.name | ltrimstr(\"v\") | split(\".\") | map(tonumber)) | reverse | .[].name")
+      if [ -z "$TAG" ]; then
+        TAG_COUNT=$(gh api "repos/$FULL/tags?per_page=1" --jq length 2>/dev/null || echo 0)
+        if [ "$TAG_COUNT" -gt 0 ]; then
+          die 4 "every semver tag of $FULL is younger than $MIN_AGE_DAYS days; wait, pin an older @ref, or pass --allow-fresh"
+        fi
+        # Nothing to pin to but a branch. Pin its HEAD so the ref is at least immutable,
+        # and say so: Dependabot will not bump a branch SHA, so this pin needs a human.
+        BRANCH=$(gh api "repos/$FULL" --jq .default_branch)
+        SHA=$(gh api "repos/$FULL/commits/$BRANCH" --jq .sha)
+        PUBLISHED=$(commit_date "$SHA")
+        SOURCE="branch"
+        TAG="$BRANCH ${PUBLISHED%%T*}"
+        echo "pin-action: $FULL has no tags or releases; pinning HEAD of '$BRANCH'. Dependabot cannot update a branch pin, so ask the owner to tag releases." >&2
+      fi
     fi
   fi
 fi
 
-SHA=$(tag_to_commit "$TAG")
+[ "$SOURCE" = "branch" ] || SHA=$(tag_to_commit "$TAG")
 
 # A moving major tag (v4) points at some exact release (v4.2.1). Prefer the most
 # specific tag name on the same commit so the comment says which version was pinned.
-SPECIFIC=$(gh api "repos/$FULL/tags?per_page=100" \
+SPECIFIC=""
+[ "$SOURCE" = "branch" ] || SPECIFIC=$(gh api "repos/$FULL/tags?per_page=100" \
   --jq "[.[] | select(.commit.sha==\"$SHA\") | .name] | sort_by(length) | last // empty" 2>/dev/null) || SPECIFIC=""
 if [ -n "$SPECIFIC" ] && [ "$SPECIFIC" != "$TAG" ]; then
   TAG="$SPECIFIC"


### PR DESCRIPTION
Part 3 of 11 in stack #13 (`gha-skill/skill-rewrite`, base `gha-skill/references`). Review bottom-up; each layer was diff-reviewed before its commit.

## Changes
- **Rewrite SKILL.md as router plus checklist; fix references and pin-action from manual runs**

## Verification
- Manual runs on this repo and docker-build-workflow; iteration-2: 39/39 vs 38/39 for the old flat skill.
- `make lint` clean at the layer's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yRNwbvpf198fiYZHgkt1w