### PR TITLE
Add audit, speed, and small-edit evals with fixtures

### DIFF
--- a/skills/github-actions-workflow-pro/evals/evals.json
+++ b/skills/github-actions-workflow-pro/evals/evals.json
@@ -39,6 +39,60 @@
         "The answer recommends or implements AWS OIDC instead of long-lived AWS access key secrets.",
         "The corrected workflow includes concurrency, caching, and timeouts where appropriate."
       ]
+    },
+    {
+      "id": 3,
+      "prompt": "Audit this workflow (.github/workflows/ci.yml, attached) for security problems. Give me a report of what is wrong and a corrected version.",
+      "expected_output": "An audit report that separates hard findings from opinions, identifies pull_request_target with untrusted checkout, write-all permissions, unpinned actions, template injection of the PR title, and static AWS keys, and a corrected workflow that passes actionlint and zizmor.",
+      "files": [
+        "evals/fixtures/insecure-ci.yml"
+      ],
+      "expectations": [
+        "The report identifies pull_request_target combined with checking out the PR head as a critical risk and moves the workflow to pull_request or isolates the untrusted checkout.",
+        "The report identifies the PR title interpolated directly into a run: block as template injection, and the corrected workflow no longer interpolates it into a shell (passed through env, or the step removed).",
+        "The corrected workflow replaces permissions: write-all with permissions: {} at the top and explicit per-job grants.",
+        "The corrected workflow pins actions/checkout and actions/setup-node to full commit SHAs with a version comment.",
+        "The report recommends OIDC for AWS instead of the static access key secrets.",
+        "The report separates tool-backed or rule-backed hard findings from opinion or style items under distinct headings.",
+        "The answer states that actionlint and zizmor were run on the corrected file, or names them as not installed."
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "Our CI (.github/workflows/ci.yml, attached) takes about 25 minutes on every push and people have started ignoring it. Speed it up without dropping real coverage.",
+      "expected_output": "A faster workflow that adds concurrency cancellation, npm caching, timeouts, drops the redundant fetch-depth: 0 and duplicate matrix cell, runs lint and test in parallel, adds Buildx cache for the image build, keeps the existing pins and permissions, and explains why each change helps.",
+      "files": [
+        "evals/fixtures/slow-ci.yml"
+      ],
+      "expectations": [
+        "The workflow gains a concurrency block with cancel-in-progress for superseded runs.",
+        "setup-node gains cache: npm or an equivalent package-manager cache.",
+        "The redundant matrix cell is removed or explained: ubuntu-latest and ubuntu-24.04 are the same runner, so the matrix shrinks without losing coverage.",
+        "fetch-depth: 0 is removed from jobs that do not need history, or its removal is proposed with the reason.",
+        "Lint and test no longer run strictly sequentially, or the answer justifies keeping needs: lint.",
+        "Jobs gain timeout-minutes.",
+        "The docker build step moves to docker/setup-buildx-action and docker/build-push-action with type=gha cache, or the answer recommends that change.",
+        "The existing SHA pins and permissions block are preserved, not loosened.",
+        "Each speed change is explained with the reason it saves time."
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Add a job to my CI workflow (.github/workflows/ci.yml, attached) that runs `npm run lint`. Keep everything else as it is.",
+      "expected_output": "The same workflow with one new lint job that matches the existing job's conventions: permissions block, same pinned checkout and setup-node with version comments, persist-credentials: false, npm cache, timeout, friendly name, running in parallel with the test job. No unrelated changes.",
+      "files": [
+        "evals/fixtures/good-ci.yml"
+      ],
+      "expectations": [
+        "The new lint job has its own permissions block with contents: read.",
+        "The new lint job uses the same full-SHA pins and version comments for actions/checkout and actions/setup-node as the existing test job.",
+        "The new lint job sets persist-credentials: false on checkout and cache: npm on setup-node, matching the existing job.",
+        "The new lint job has a timeout-minutes and a human-friendly name.",
+        "The lint job runs in parallel with the test job rather than being chained with needs, or the answer justifies chaining.",
+        "The existing test job, triggers, permissions, and concurrency block are unchanged.",
+        "No path filters, workflow_dispatch, or other unrequested triggers are added.",
+        "The answer states that actionlint and zizmor were run, or names them as not installed."
+      ]
     }
   ]
 }

--- a/skills/github-actions-workflow-pro/evals/fixtures/good-ci.yml
+++ b/skills/github-actions-workflow-pro/evals/fixtures/good-ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Check out source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test

--- a/skills/github-actions-workflow-pro/evals/fixtures/insecure-ci.yml
+++ b/skills/github-actions-workflow-pro/evals/fixtures/insecure-ci.yml
@@ -1,0 +1,27 @@
+name: ci
+on:
+  pull_request_target:
+  push:
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci && npm test
+      - name: comment
+        run: |
+          echo "PR title: ${{ github.event.pull_request.title }}"
+          gh pr comment ${{ github.event.pull_request.number }} --body "tests passed"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: deploy
+        run: aws s3 sync ./dist s3://widget-api-prod
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/skills/github-actions-workflow-pro/evals/fixtures/slow-ci.yml
+++ b/skills/github-actions-workflow-pro/evals/fixtures/slow-ci.yml
@@ -1,0 +1,41 @@
+name: Tests
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm run lint
+  test:
+    name: Test
+    needs: lint
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04]
+        node: [20, 22]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci
+      - run: npm test
+  build:
+    name: Build Image
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - run: docker build -t widget-api:${{ github.sha }} .


### PR DESCRIPTION
Part 4 of 11 in stack #13 (`gha-skill/evals-expand`, base `gha-skill/skill-rewrite`). Review bottom-up; each layer was diff-reviewed before its commit.

## Changes
- **Add audit, speed, and small-edit evals with fixtures**

## Verification
- Iteration-2 evals 0–5 all pass; fixtures committed under `evals/fixtures/`.
- `make lint` clean at the layer's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yRNwbvpf198fiYZHgkt1w