### PR TITLE
Format Markdown and JSON with prettier; add make fmt and lint-fmt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,12 +20,12 @@ skills/<skill-name>/          # SOURCE — committed
 
 There are two different things, and they live in two different places:
 
-- **Eval definitions** — the prompts and assertions that *define* each test.
+- **Eval definitions** — the prompts and assertions that _define_ each test.
   These live next to the skill at `skills/<skill-name>/evals/evals.json` and **are committed**.
   They are the contract for the skill: a reviewer reads them to know what behavior must hold,
   and they let anyone re-run the evals later to catch regressions.
 
-- **Eval run artifacts** — the *output* of executing those evals (transcripts, gradings,
+- **Eval run artifacts** — the _output_ of executing those evals (transcripts, gradings,
   timings, `benchmark.json`/`benchmark.md`, viewer logs).
   These go in **`.evals/<skill-name>/iteration-N/`** at the repo root, which is **gitignored**.
   They are regenerated on every run and are machine-specific, so they are not source of truth.
@@ -47,7 +47,7 @@ skill folder and commit just that — do not commit the rest of `.evals/`.
 
 ## Before committing
 
-Run `make lint`. It runs `markdownlint` and `yamllint` (configs in `.github/linters/`, the same files super-linter reads in CI), `shellcheck` on every
+Run `make lint` (and `make fmt` first if prettier complains). It runs `markdownlint`, `prettier --check`, and `yamllint` (configs in `.github/linters/`, the same files super-linter reads in CI), `shellcheck` on every
 `skills/*/scripts/*.sh`, `py_compile` on `skills/*/scripts/*.py`, and `actionlint` + `zizmor` + `poutine` + `pinact -check` on this repo's workflows (actionlint also on the well-formed eval fixtures).
 Tools are never installed by the Makefile; a missing one prints its `brew install` formula.
 

--- a/Makefile
+++ b/Makefile
@@ -11,18 +11,28 @@ EVAL_DIR       = .evals/$(SKILL)/iteration-$(ITER)
 # `need` fails with an install hint when a tool is absent.
 need = command -v $(1) >/dev/null 2>&1 || { echo "missing: $(1)  ->  brew install $(2)"; exit 1; }
 
-.PHONY: help lint lint-md lint-yaml lint-sh lint-py lint-actions lint-pins eval-benchmark eval-view pin run-stats
+.PHONY: help lint lint-md lint-fmt lint-yaml lint-sh lint-py lint-actions lint-pins fmt eval-benchmark eval-view pin run-stats
 
 help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## ' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  %-16s %s\n", $$1, $$2}'
 	@echo
 	@echo "Variables: SKILL=$(SKILL)  ITER=$(ITER)  SKILL_CREATOR=$(SKILL_CREATOR)"
 
-lint: lint-md lint-yaml lint-sh lint-py lint-actions lint-pins ## Run every linter (pre-commit gate)
+lint: lint-md lint-fmt lint-yaml lint-sh lint-py lint-actions lint-pins ## Run every linter (pre-commit gate)
 
 lint-md: ## markdownlint on all Markdown (config: .github/linters/.markdown-lint.yml, shared with CI)
 	@$(call need,markdownlint,markdownlint-cli)
 	markdownlint -c .github/linters/.markdown-lint.yml '**/*.md' --ignore node_modules --ignore .evals --ignore CLAUDE.md
+
+PRETTIER_FILES = "**/*.md" "**/*.json" "!.evals/**" "!.agents/**" "!node_modules/**" "!CLAUDE.md"
+
+lint-fmt: ## prettier --check on Markdown and JSON (super-linter runs the same check in CI)
+	@$(call need,prettier,prettier)
+	prettier --check $(PRETTIER_FILES)
+
+fmt: ## prettier --write on Markdown and JSON
+	@$(call need,prettier,prettier)
+	prettier --write $(PRETTIER_FILES)
 
 lint-yaml: ## yamllint on all YAML (config: .github/linters/.yaml-lint.yml, shared with CI)
 	@$(call need,yamllint,yamllint)

--- a/PLAN.md
+++ b/PLAN.md
@@ -8,13 +8,13 @@ Open work for this repo, in rough priority order. Done items move to the changel
 
 **Verified images (2026-08-25):**
 
-| Tool | Image | Example |
-| --- | --- | --- |
-| actionlint | `rhysd/actionlint:latest` (Docker Hub, official; docs/usage.md "Docker") | `docker run --rm -v "$PWD:/repo:ro" --workdir /repo rhysd/actionlint:latest -color` |
-| zizmor | `ghcr.io/zizmorcore/zizmor:latest` (official; docs/installation.md "Docker") | `docker run --rm -v "$PWD:/src:ro" -e GH_TOKEN ghcr.io/zizmorcore/zizmor:latest --collect=all /src` |
-| poutine | `ghcr.io/boostsecurityio/poutine:latest` (official; README) | `docker run --rm -v "$PWD:/repo:ro" ghcr.io/boostsecurityio/poutine:latest analyze_local /repo --format json --quiet --disable-version-check` |
-| gasa | `ghcr.io/bretfisher/gasa:latest` (official; README; pin `:vX.Y.Z`) | `docker run --rm -e GITHUB_TOKEN ghcr.io/bretfisher/gasa:latest run owner/repo --format json` (API-only, no mount needed) |
-| pinact | **none** (Homebrew core, aqua, mise, GitHub Releases binaries; Go, single static binary) | would need our image (below) or a generic Go/Alpine image plus the release tarball |
+| Tool       | Image                                                                                    | Example                                                                                                                                       |
+| ---------- | ---------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| actionlint | `rhysd/actionlint:latest` (Docker Hub, official; docs/usage.md "Docker")                 | `docker run --rm -v "$PWD:/repo:ro" --workdir /repo rhysd/actionlint:latest -color`                                                           |
+| zizmor     | `ghcr.io/zizmorcore/zizmor:latest` (official; docs/installation.md "Docker")             | `docker run --rm -v "$PWD:/src:ro" -e GH_TOKEN ghcr.io/zizmorcore/zizmor:latest --collect=all /src`                                           |
+| poutine    | `ghcr.io/boostsecurityio/poutine:latest` (official; README)                              | `docker run --rm -v "$PWD:/repo:ro" ghcr.io/boostsecurityio/poutine:latest analyze_local /repo --format json --quiet --disable-version-check` |
+| gasa       | `ghcr.io/bretfisher/gasa:latest` (official; README; pin `:vX.Y.Z`)                       | `docker run --rm -e GITHUB_TOKEN ghcr.io/bretfisher/gasa:latest run owner/repo --format json` (API-only, no mount needed)                     |
+| pinact     | **none** (Homebrew core, aqua, mise, GitHub Releases binaries; Go, single static binary) | would need our image (below) or a generic Go/Alpine image plus the release tarball                                                            |
 
 Pin image tags (or digests, per `docker-pro`) once the option lands; `latest` is only for the table above.
 

--- a/README.md
+++ b/README.md
@@ -6,44 +6,45 @@ Installable via `npx skills add https://github.com/bretfisher/skills` and mark t
 
 ## Skills
 
-| Name | Purpose |
-| --- | --- |
-| `docker-pro` | Light up all the best docker features and security best practices for dockerizing a repo. From a Docker Captain. |
+| Name                          | Purpose                                                                                                                                                                                                                                                                              |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `docker-pro`                  | Light up all the best docker features and security best practices for dockerizing a repo. From a Docker Captain.                                                                                                                                                                     |
 | `github-actions-workflow-pro` | Create, edit, audit, and speed up GitHub Actions workflows with opinionated security and speed defaults. Fires on its own whenever a `.github/workflows/*` file is in play. Ships `references/` (security, speed, audit) and `scripts/run-stats.py`; pinning is delegated to pinact. |
-| `gha-audit` | Type `/gha-audit [file]` to run the audit path of `github-actions-workflow-pro` on demand: tools first (`actionlint`, `zizmor`, `poutine`, `pinact`, `gasa`), then a report split into correctness, hard findings, speed, and opinions, plus a proposed diff. User-invoked only. |
-| `super-linting` | Picks the right linter for every file type in a project and wires them into a `make lint` target plus an agent-guide contract so code is linted before every commit. Focused on local developer/agent linting, not CI. |
+| `gha-audit`                   | Type `/gha-audit [file]` to run the audit path of `github-actions-workflow-pro` on demand: tools first (`actionlint`, `zizmor`, `poutine`, `pinact`, `gasa`), then a report split into correctness, hard findings, speed, and opinions, plus a proposed diff. User-invoked only.     |
+| `super-linting`               | Picks the right linter for every file type in a project and wires them into a `make lint` target plus an agent-guide contract so code is linted before every commit. Focused on local developer/agent linting, not CI.                                                               |
 
 ## Repo layout
 
-| Path | What | Committed? |
-| --- | --- | --- |
-| `skills/<name>/SKILL.md` | The skill itself: description (the trigger), working style, checklist, validate step, done-when | ✅ yes |
-| `skills/<name>/references/*.md` | Detail the skill reads only when a branch needs it (rules + the why, audit procedure) | ✅ yes |
-| `skills/<name>/scripts/*` | Deterministic helpers the skill runs instead of re-deriving (e.g. `run-stats.py`) | ✅ yes |
-| `skills/<name>/evals/evals.json` | Eval **definitions** (prompts + assertions) — the test contract | ✅ yes |
-| `skills/<name>/evals/fixtures/` | Input files some evals hand to the agent (a deliberately insecure or slow workflow) | ✅ yes |
-| `.evals/<name>/iteration-N/` | Eval **run artifacts** (transcripts, gradings, timings, benchmarks) | ❌ gitignored |
+| Path                             | What                                                                                            | Committed?    |
+| -------------------------------- | ----------------------------------------------------------------------------------------------- | ------------- |
+| `skills/<name>/SKILL.md`         | The skill itself: description (the trigger), working style, checklist, validate step, done-when | ✅ yes        |
+| `skills/<name>/references/*.md`  | Detail the skill reads only when a branch needs it (rules + the why, audit procedure)           | ✅ yes        |
+| `skills/<name>/scripts/*`        | Deterministic helpers the skill runs instead of re-deriving (e.g. `run-stats.py`)               | ✅ yes        |
+| `skills/<name>/evals/evals.json` | Eval **definitions** (prompts + assertions) — the test contract                                 | ✅ yes        |
+| `skills/<name>/evals/fixtures/`  | Input files some evals hand to the agent (a deliberately insecure or slow workflow)             | ✅ yes        |
+| `.evals/<name>/iteration-N/`     | Eval **run artifacts** (transcripts, gradings, timings, benchmarks)                             | ❌ gitignored |
 
 ## Makefile
 
 `make help` lists everything. Tools are checked, never installed; a missing one prints its `brew install` formula.
 
-| Target | What it does |
-| --- | --- |
-| `make lint` | Pre-commit gate: `markdownlint` and `yamllint` (configs in `.github/linters/`, the same files super-linter reads in CI), `shellcheck` on `skills/*/scripts/*.sh`, `py_compile` on `skills/*/scripts/*.py`, and `actionlint` + `zizmor` + `poutine` + `pinact -check` on this repo's workflows (actionlint also on the well-formed eval fixtures) |
-| `make eval-benchmark [SKILL=… ITER=…]` | Aggregate the latest `.evals/<skill>/iteration-N/` into `benchmark.json` + `benchmark.md` via the skill-creator plugin |
-| `make eval-view [SKILL=… ITER=…]` | Open the skill-creator review viewer on that iteration |
-| `make pin [FILES=…]` | Pin this repo's workflows with pinact: newest release at least 7 days old, SHA plus version comment |
-| `make run-stats [RUNS=3] [REPO=owner/repo]` | Rank a repo's workflows and jobs by mean duration over the last few runs, flag inconsistent timing and recent failures |
+| Target                                      | What it does                                                                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `make lint`                                 | Pre-commit gate: `markdownlint`, `prettier --check`, and `yamllint` (configs in `.github/linters/`, the same rules super-linter applies in CI), `shellcheck` on `skills/*/scripts/*.sh`, `py_compile` on `skills/*/scripts/*.py`, and `actionlint` + `zizmor` + `poutine` + `pinact -check` on this repo's workflows (actionlint also on the well-formed eval fixtures) |
+| `make fmt`                                  | `prettier --write` on all Markdown and JSON, so tables and JSON match what CI expects                                                                                                                                                                                                                                                                                   |
+| `make eval-benchmark [SKILL=… ITER=…]`      | Aggregate the latest `.evals/<skill>/iteration-N/` into `benchmark.json` + `benchmark.md` via the skill-creator plugin                                                                                                                                                                                                                                                  |
+| `make eval-view [SKILL=… ITER=…]`           | Open the skill-creator review viewer on that iteration                                                                                                                                                                                                                                                                                                                  |
+| `make pin [FILES=…]`                        | Pin this repo's workflows with pinact: newest release at least 7 days old, SHA plus version comment                                                                                                                                                                                                                                                                     |
+| `make run-stats [RUNS=3] [REPO=owner/repo]` | Rank a repo's workflows and jobs by mean duration over the last few runs, flag inconsistent timing and recent failures                                                                                                                                                                                                                                                  |
 
 `SKILL` defaults to `github-actions-workflow-pro`; `ITER` defaults to the highest iteration present.
 
 ### Skill evals
 
-Eval *definitions* live next to each skill (`skills/<name>/evals/evals.json`) and are committed —
+Eval _definitions_ live next to each skill (`skills/<name>/evals/evals.json`) and are committed —
 they document what each skill is supposed to do and let anyone re-run the evals to catch regressions.
 
-Eval *run artifacts* (the output of executing those evals) are written to `.evals/<name>/iteration-N/`
+Eval _run artifacts_ (the output of executing those evals) are written to `.evals/<name>/iteration-N/`
 at the repo root, which is gitignored. They're regenerated on every run and machine-specific, so they
 aren't source of truth. When running the skill-creator eval loop, point its workspace at
 `.evals/<name>/` rather than the default `<name>-workspace/` sibling.

--- a/skills/github-actions-workflow-pro/evals/coverage.md
+++ b/skills/github-actions-workflow-pro/evals/coverage.md
@@ -9,70 +9,70 @@ Which assertion in `evals.json` proves each rule the skill states. Two kinds of 
 
 ## SKILL.md checklist
 
-| Line | Proof | Assertions |
-| --- | --- | --- |
-| `permissions: {}` + least-privilege per job | scanner (zizmor `excessive-permissions`, gasa) + agent | mech; e0#2 e1#4 e2#2 e3#3 e5#1 |
-| `checkout` needs `contents: read` | agent (runtime failure, no scanner) | e5#1, and any eval whose output checks out and passes mech |
-| `persist-credentials: false` | scanner (zizmor `artipacked`) | mech; e5#3 e7#5 |
-| Third-party `uses:` SHA + version comment | scanner (zizmor `unpinned-uses`, `ref-version-mismatch`; gasa) | mech; e3#4 e5#2 |
-| Release at least 7 days old | scanner (pinact `-verify-min-age`) | mech (pinact `-min-age 7 -verify-min-age` in the grader's run) |
-| Same-owner `@main` replaced | scanner (gasa, zizmor) | mech |
-| OIDC over static cloud keys | agent | e2#4 e3#5 e7#1 |
-| Secrets scoped to an environment | scanner (zizmor `secrets-outside-env`, auditor) + agent | e7#3 |
-| `github.event.*` through `env:` | scanner (actionlint, zizmor, poutine) | mech; e3#2 |
-| `pull_request` not `pull_request_target` | scanner (zizmor, gasa, poutine) | mech; e2#1 e3#1 |
-| Dependabot entry with cooldown | scanner (zizmor `dependabot-cooldown`, gasa `updates/*`) + agent offer | e7#6 |
-| Superseded runs cancel (CI) | scanner (zizmor `concurrency-limits`, pedantic) + agent | e0#3 e4#1 |
-| Deploy/release in a non-cancelling group | agent | e6#6 e7#2 |
-| Cheap jobs first and parallel | agent | e4#5 e5#5 e8#2 |
-| Cache via setup action | agent | e0#4 e4#2 e5#3 |
-| `timeout-minutes` | agent | e0#5 e4#6 e5#4 e7#5 |
-| Path filters only when correct; none on new CI | agent | e5#7 e8#6 |
-| Ask before manual/remote triggers | agent | e5#7 e8#6 |
+| Line                                           | Proof                                                                  | Assertions                                                     |
+| ---------------------------------------------- | ---------------------------------------------------------------------- | -------------------------------------------------------------- |
+| `permissions: {}` + least-privilege per job    | scanner (zizmor `excessive-permissions`, gasa) + agent                 | mech; e0#2 e1#4 e2#2 e3#3 e5#1                                 |
+| `checkout` needs `contents: read`              | agent (runtime failure, no scanner)                                    | e5#1, and any eval whose output checks out and passes mech     |
+| `persist-credentials: false`                   | scanner (zizmor `artipacked`)                                          | mech; e5#3 e7#5                                                |
+| Third-party `uses:` SHA + version comment      | scanner (zizmor `unpinned-uses`, `ref-version-mismatch`; gasa)         | mech; e3#4 e5#2                                                |
+| Release at least 7 days old                    | scanner (pinact `-verify-min-age`)                                     | mech (pinact `-min-age 7 -verify-min-age` in the grader's run) |
+| Same-owner `@main` replaced                    | scanner (gasa, zizmor)                                                 | mech                                                           |
+| OIDC over static cloud keys                    | agent                                                                  | e2#4 e3#5 e7#1                                                 |
+| Secrets scoped to an environment               | scanner (zizmor `secrets-outside-env`, auditor) + agent                | e7#3                                                           |
+| `github.event.*` through `env:`                | scanner (actionlint, zizmor, poutine)                                  | mech; e3#2                                                     |
+| `pull_request` not `pull_request_target`       | scanner (zizmor, gasa, poutine)                                        | mech; e2#1 e3#1                                                |
+| Dependabot entry with cooldown                 | scanner (zizmor `dependabot-cooldown`, gasa `updates/*`) + agent offer | e7#6                                                           |
+| Superseded runs cancel (CI)                    | scanner (zizmor `concurrency-limits`, pedantic) + agent                | e0#3 e4#1                                                      |
+| Deploy/release in a non-cancelling group       | agent                                                                  | e6#6 e7#2                                                      |
+| Cheap jobs first and parallel                  | agent                                                                  | e4#5 e5#5 e8#2                                                 |
+| Cache via setup action                         | agent                                                                  | e0#4 e4#2 e5#3                                                 |
+| `timeout-minutes`                              | agent                                                                  | e0#5 e4#6 e5#4 e7#5                                            |
+| Path filters only when correct; none on new CI | agent                                                                  | e5#7 e8#6                                                      |
+| Ask before manual/remote triggers              | agent                                                                  | e5#7 e8#6                                                      |
 
 ## Building a workflow
 
-| Line | Proof | Assertions |
-| --- | --- | --- |
-| Ask only about decisions; infer facts | agent | e0#9 e8#4 |
-| Runtime version from `.nvmrc` / `engines` | agent | e8#1 |
-| Conventional filenames | agent | e8#5 (e0/e1 name the file in the prompt) |
-| pinact for every third-party `uses:` | scanner | mech (pinact `-check` clean means every pin is a SHA with a correct comment) |
-| Reusable-workflow offer; repo's own linter wins | agent | e8#2 e8#3 |
+| Line                                            | Proof   | Assertions                                                                   |
+| ----------------------------------------------- | ------- | ---------------------------------------------------------------------------- |
+| Ask only about decisions; infer facts           | agent   | e0#9 e8#4                                                                    |
+| Runtime version from `.nvmrc` / `engines`       | agent   | e8#1                                                                         |
+| Conventional filenames                          | agent   | e8#5 (e0/e1 name the file in the prompt)                                     |
+| pinact for every third-party `uses:`            | scanner | mech (pinact `-check` clean means every pin is a SHA with a correct comment) |
+| Reusable-workflow offer; repo's own linter wins | agent   | e8#2 e8#3                                                                    |
 
 ## Maintainable YAML and Container images
 
-| Line | Proof | Assertions |
-| --- | --- | --- |
-| Friendly names | scanner (zizmor `anonymous-definition`, pedantic) + agent | e0#5 e5#4 |
-| Explicit triggers | agent | e0#1 e1#1 |
-| `set -euo pipefail` | agent | e7#4 |
-| Trusted refs only for publish; buildx/metadata/build-push; ghcr; `packages: write` scoped; gha cache; provenance/SBOM | agent | e1#1–#5 e1#8 e4#7 |
+| Line                                                                                                                  | Proof                                                     | Assertions        |
+| --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ----------------- |
+| Friendly names                                                                                                        | scanner (zizmor `anonymous-definition`, pedantic) + agent | e0#5 e5#4         |
+| Explicit triggers                                                                                                     | agent                                                     | e0#1 e1#1         |
+| `set -euo pipefail`                                                                                                   | agent                                                     | e7#4              |
+| Trusted refs only for publish; buildx/metadata/build-push; ghcr; `packages: write` scoped; gha cache; provenance/SBOM | agent                                                     | e1#1–#5 e1#8 e4#7 |
 
 ## Validate and Done-when
 
-| Line | Proof | Assertions |
-| --- | --- | --- |
-| Scanners run or named absent | agent | e0#7 e1#7 e2#7 e3#7 e4#11 e5#8 |
-| Every job has `permissions:`; `permissions: {}` at top | scanner + agent | mech; e0#2 e5#1 |
-| Every third-party `uses:` SHA-pinned | scanner | mech |
-| Placeholders listed | agent | e2#8 e7#7 |
-| Hand-back explains each default | agent | e0#8 e1#8 e2#8 e4#9 e8#7 |
+| Line                                                   | Proof           | Assertions                     |
+| ------------------------------------------------------ | --------------- | ------------------------------ |
+| Scanners run or named absent                           | agent           | e0#7 e1#7 e2#7 e3#7 e4#11 e5#8 |
+| Every job has `permissions:`; `permissions: {}` at top | scanner + agent | mech; e0#2 e5#1                |
+| Every third-party `uses:` SHA-pinned                   | scanner         | mech                           |
+| Placeholders listed                                    | agent           | e2#8 e7#7                      |
+| Hand-back explains each default                        | agent           | e0#8 e1#8 e2#8 e4#9 e8#7       |
 
 ## audit.md
 
-| Line | Proof | Assertions |
-| --- | --- | --- |
-| Covers every workflow in the repo | agent | e6#6 |
-| Run history: failures documented, still-failing → ask to troubleshoot | agent | not asserted (fixture repos have no remote). Gap: needs a live-repo eval |
-| Speed ranking, spread ratio, one-sentence fix or ask | agent | e6#6 partial |
-| Scanners run, rule ids cited, no restating | agent | e6#2 e6#4 |
-| Residual-only reading | agent | e6#2 (negative form) |
-| Correctness / Hard / Speed / Opinions sections | agent | e3#6 e6#3 |
-| Do-first ≤ 5 | agent | e6#1 |
-| Ask delivery format or state default | agent | e6#5 |
-| Audit does not edit | agent | e6#7 |
-| Proposed YAML passes scanners | scanner | e6#8 |
+| Line                                                                  | Proof   | Assertions                                                               |
+| --------------------------------------------------------------------- | ------- | ------------------------------------------------------------------------ |
+| Covers every workflow in the repo                                     | agent   | e6#6                                                                     |
+| Run history: failures documented, still-failing → ask to troubleshoot | agent   | not asserted (fixture repos have no remote). Gap: needs a live-repo eval |
+| Speed ranking, spread ratio, one-sentence fix or ask                  | agent   | e6#6 partial                                                             |
+| Scanners run, rule ids cited, no restating                            | agent   | e6#2 e6#4                                                                |
+| Residual-only reading                                                 | agent   | e6#2 (negative form)                                                     |
+| Correctness / Hard / Speed / Opinions sections                        | agent   | e3#6 e6#3                                                                |
+| Do-first ≤ 5                                                          | agent   | e6#1                                                                     |
+| Ask delivery format or state default                                  | agent   | e6#5                                                                     |
+| Audit does not edit                                                   | agent   | e6#7                                                                     |
+| Proposed YAML passes scanners                                         | scanner | e6#8                                                                     |
 
 ## Known gaps
 

--- a/skills/github-actions-workflow-pro/evals/evals.json
+++ b/skills/github-actions-workflow-pro/evals/evals.json
@@ -56,9 +56,7 @@
       "id": 3,
       "prompt": "Audit this workflow (.github/workflows/ci.yml, attached) for security problems. Give me a report of what is wrong and a corrected version.",
       "expected_output": "An audit report that separates hard findings from opinions, identifies pull_request_target with untrusted checkout, write-all permissions, unpinned actions, template injection of the PR title, and static AWS keys, and a corrected workflow that passes actionlint and zizmor.",
-      "files": [
-        "evals/fixtures/insecure-ci.yml"
-      ],
+      "files": ["evals/fixtures/insecure-ci.yml"],
       "expectations": [
         "The report identifies pull_request_target combined with checking out the PR head as a critical risk and moves the workflow to pull_request or isolates the untrusted checkout.",
         "The report identifies the PR title interpolated directly into a run: block as template injection, and the corrected workflow no longer interpolates it into a shell (passed through env, or the step removed).",
@@ -74,9 +72,7 @@
       "id": 4,
       "prompt": "Our CI (.github/workflows/ci.yml, attached) takes about 25 minutes on every push and people have started ignoring it. Speed it up without dropping real coverage.",
       "expected_output": "A faster workflow that adds concurrency cancellation, npm caching, timeouts, drops the redundant fetch-depth: 0 and duplicate matrix cell, runs lint and test in parallel, adds Buildx cache for the image build, keeps the existing pins and permissions, and explains why each change helps.",
-      "files": [
-        "evals/fixtures/slow-ci.yml"
-      ],
+      "files": ["evals/fixtures/slow-ci.yml"],
       "expectations": [
         "The workflow gains a concurrency block with cancel-in-progress for superseded runs.",
         "setup-node gains cache: npm or an equivalent package-manager cache.",
@@ -95,9 +91,7 @@
       "id": 5,
       "prompt": "Add a job to my CI workflow (.github/workflows/ci.yml, attached) that runs `npm run lint`. Keep everything else as it is.",
       "expected_output": "The same workflow with one new lint job that matches the existing job's conventions: permissions block, same pinned checkout and setup-node with version comments, persist-credentials: false, npm cache, timeout, friendly name, running in parallel with the test job. No unrelated changes.",
-      "files": [
-        "evals/fixtures/good-ci.yml"
-      ],
+      "files": ["evals/fixtures/good-ci.yml"],
       "expectations": [
         "The new lint job has its own permissions block with contents: read.",
         "The new lint job uses the same full-SHA pins and version comments for actions/checkout and actions/setup-node as the existing test job.",
@@ -134,9 +128,7 @@
       "id": 7,
       "prompt": "Harden my deploy workflow (.github/workflows/deploy.yml, attached). We deploy a static site to S3 and CloudFront from main.",
       "expected_output": "A hardened deploy workflow using OIDC instead of static AWS keys, a non-cancelling concurrency group, an environment scoping the secrets, set -euo pipefail in the multi-line run block, persist-credentials: false, a timeout, an offer of the Dependabot snippet, and placeholders listed.",
-      "files": [
-        "evals/fixtures/deploy-static-keys.yml"
-      ],
+      "files": ["evals/fixtures/deploy-static-keys.yml"],
       "expectations": [
         "The corrected workflow replaces AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY with aws-actions/configure-aws-credentials using role-to-assume and id-token: write.",
         "The deploy job's concurrency no longer cancels in-progress runs (cancel-in-progress: false or a queue), with the reason given.",

--- a/skills/github-actions-workflow-pro/evals/fixtures/node-repo/package-lock.json
+++ b/skills/github-actions-workflow-pro/evals/fixtures/node-repo/package-lock.json
@@ -1,1 +1,5 @@
-{"name":"widget-api","lockfileVersion":3,"packages":{}}
+{
+  "name": "widget-api",
+  "lockfileVersion": 3,
+  "packages": {}
+}

--- a/skills/github-actions-workflow-pro/evals/fixtures/node-repo/package.json
+++ b/skills/github-actions-workflow-pro/evals/fixtures/node-repo/package.json
@@ -7,5 +7,7 @@
     "test": "node --test test/",
     "build": "node scripts/build.js"
   },
-  "devDependencies": { "eslint": "^9.0.0" }
+  "devDependencies": {
+    "eslint": "^9.0.0"
+  }
 }

--- a/skills/github-actions-workflow-pro/references/audit.md
+++ b/skills/github-actions-workflow-pro/references/audit.md
@@ -32,13 +32,13 @@ GITHUB_TOKEN=$(gh auth token) pinact run -check -verify-comment -min-age 7 -veri
 
 What each one owns:
 
-| Tool | Owns (rule ids you will cite) | Notes |
-| --- | --- | --- |
-| `actionlint` | YAML schema and typos, expression typing, `needs:` cycles, duplicate matrix values, invalid runner labels, `shellcheck` on `run:` (when shellcheck is installed), script injection, deprecated `::set-output` and outdated action runtimes | Syntax correctness lives here; anything it reports is Hard or Correctness |
-| `zizmor` | `excessive-permissions`, `unpinned-uses`, `ref-version-mismatch`, `artipacked`, `template-injection`, `dangerous-triggers`, `secrets-outside-env`, `dependabot-cooldown`, `concurrency-limits`, `cache-poisoning`, `known-vulnerable-actions`, `impostor-commit`, `typosquat-uses`, `archived-uses`, `overprovisioned-secrets`, `unredacted-secrets`, `github-env`, `bot-conditions`, `unsound-condition`, `secrets-inherit`, `unpinned-images`, and the rest of its ~40 audits | Persona decides the bucket: `regular` findings are Hard; `pedantic`/`auditor`-only findings are Opinion, except `secrets-outside-env` (Hard), `concurrency-limits` (Speed), and `ref-version-mismatch` for a missing comment (Hard), because those are `security.md`/`speed.md` rules. Inline `# zizmor: ignore[...]` comments and `zizmor.yml` suppress; see the precedence rule in step 4 |
-| `poutine` | `injection`, `untrusted_checkout_exec`, `confused_deputy_auto_merge`, `default_permissions_on_risky_events`, `job_all_secrets`, `unverified_script_exec` (`curl \| bash`), `known_vulnerability_in_build_component`, `pr_runs_on_self_hosted`, `unpinnable_action`, `github_action_from_unverified_creator_used`, `if_always_true`, `debug_enabled` | Overlaps zizmor on injection and dangerous triggers; report each finding once, citing both ids. `error` is Hard, `warning` is Hard, `note` is Opinion |
-| `pinact` | unpinned `uses:` (prints the pin it would write), wrong or missing version comment (`-verify-comment`), pin younger than the minimum age (`-verify-min-age`, logged as `min-age violation`), branch refs it cannot pin (`action can't be pinned`) | The only tool that knows release age. Overlaps zizmor `unpinned-uses` and gasa on the bare "not a SHA" case; cite both. Its proposed pins go straight into the diff (`pinact run -update -min-age 7` on the scratch copy) |
-| `gasa` | `workflows/pull-request-target`, `workflows/action-version-pinning` (incl. same-owner branch refs), `workflows/workflow-permissions`, `workflows/write-all-permissions`, `updates/*` (Dependabot or Renovate present, `github-actions` ecosystem, cooldown, SHA-pin support), `actions/permissions/*` (repo settings: default token permissions, fork-PR approval, allowed actions, SHA-pin requirement, actions approving PRs) | The only tool that sees repository settings. Each finding carries `doc_url`; run `gasa rules` only when one does not |
+| Tool         | Owns (rule ids you will cite)                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Notes                                                                                                                                                                                                                                                                                                                                                                                       |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `actionlint` | YAML schema and typos, expression typing, `needs:` cycles, duplicate matrix values, invalid runner labels, `shellcheck` on `run:` (when shellcheck is installed), script injection, deprecated `::set-output` and outdated action runtimes                                                                                                                                                                                                                                      | Syntax correctness lives here; anything it reports is Hard or Correctness                                                                                                                                                                                                                                                                                                                   |
+| `zizmor`     | `excessive-permissions`, `unpinned-uses`, `ref-version-mismatch`, `artipacked`, `template-injection`, `dangerous-triggers`, `secrets-outside-env`, `dependabot-cooldown`, `concurrency-limits`, `cache-poisoning`, `known-vulnerable-actions`, `impostor-commit`, `typosquat-uses`, `archived-uses`, `overprovisioned-secrets`, `unredacted-secrets`, `github-env`, `bot-conditions`, `unsound-condition`, `secrets-inherit`, `unpinned-images`, and the rest of its ~40 audits | Persona decides the bucket: `regular` findings are Hard; `pedantic`/`auditor`-only findings are Opinion, except `secrets-outside-env` (Hard), `concurrency-limits` (Speed), and `ref-version-mismatch` for a missing comment (Hard), because those are `security.md`/`speed.md` rules. Inline `# zizmor: ignore[...]` comments and `zizmor.yml` suppress; see the precedence rule in step 4 |
+| `poutine`    | `injection`, `untrusted_checkout_exec`, `confused_deputy_auto_merge`, `default_permissions_on_risky_events`, `job_all_secrets`, `unverified_script_exec` (`curl \| bash`), `known_vulnerability_in_build_component`, `pr_runs_on_self_hosted`, `unpinnable_action`, `github_action_from_unverified_creator_used`, `if_always_true`, `debug_enabled`                                                                                                                             | Overlaps zizmor on injection and dangerous triggers; report each finding once, citing both ids. `error` is Hard, `warning` is Hard, `note` is Opinion                                                                                                                                                                                                                                       |
+| `pinact`     | unpinned `uses:` (prints the pin it would write), wrong or missing version comment (`-verify-comment`), pin younger than the minimum age (`-verify-min-age`, logged as `min-age violation`), branch refs it cannot pin (`action can't be pinned`)                                                                                                                                                                                                                               | The only tool that knows release age. Overlaps zizmor `unpinned-uses` and gasa on the bare "not a SHA" case; cite both. Its proposed pins go straight into the diff (`pinact run -update -min-age 7` on the scratch copy)                                                                                                                                                                   |
+| `gasa`       | `workflows/pull-request-target`, `workflows/action-version-pinning` (incl. same-owner branch refs), `workflows/workflow-permissions`, `workflows/write-all-permissions`, `updates/*` (Dependabot or Renovate present, `github-actions` ecosystem, cooldown, SHA-pin support), `actions/permissions/*` (repo settings: default token permissions, fork-PR approval, allowed actions, SHA-pin requirement, actions approving PRs)                                                 | The only tool that sees repository settings. Each finding carries `doc_url`; run `gasa rules` only when one does not                                                                                                                                                                                                                                                                        |
 
 Then read each workflow once, top to bottom, for the **residual list**, the rules no tool checks:
 
@@ -73,29 +73,38 @@ Deliver in the format the user chose in step 1 (or the stated chat default). Wha
 
 ```markdown
 ## Do first
+
 1. <the one thing to fix today, with its section and file:line>
-...
+   ...
 
 ## Correctness
+
 - high <file>:<line> — <what is broken, with the evidence: run id, log line>. Fix: <the change>.
 
 ## Recent failures
+
 - <workflow>: run <id> "<title>" <date> <conclusion> (still failing on latest run?) — <url>
 
 ## Hard findings
+
 - <severity> `<rule id>` <file>:<line> — <what is wrong in one line>. Fix: <the change>.
 
 ## Speed
+
 <ranked workflow table> <ranked job table>
+
 - <workflow / job> — <mean over N runs, spread> — <one-sentence fix, or "needs run-log research; want me to?">
 
 ## Opinions
+
 - <file> — <convention>, opinion. <one-line why it helps>.
 
 ## Proposed diff
+
 <unified diff, or the full corrected file when most lines change>
 
 ## Tools
+
 actionlint <version|absent>, shellcheck <version|absent>, zizmor <version|absent> (<online|offline>, persona auditor), poutine <version|absent>, pinact <version|absent>, gasa <version|absent|skipped: reason>, run-stats <N runs|skipped: reason>
 ```
 

--- a/skills/github-actions-workflow-pro/references/security.md
+++ b/skills/github-actions-workflow-pro/references/security.md
@@ -23,7 +23,7 @@ pinact run <file>                             # keep the version as written, jus
 pinact run -check -verify-comment -min-age 7 -verify-min-age   # audit: report unpinned, wrong comments, too-fresh pins; edits nothing
 ```
 
-  `pinact run` without `-update` pins whatever the tag points at today, which can be a release from this week, so the `-update -min-age 7` form is the default for anything new. `pinact run -update` also crosses majors (v3 to v4) when the newest qualifying release is a new major; drop `-update` when the user wants to stay on the major they have.
+`pinact run` without `-update` pins whatever the tag points at today, which can be a release from this week, so the `-update -min-age 7` form is the default for anything new. `pinact run -update` also crosses majors (v3 to v4) when the newest qualifying release is a new major; drop `-update` when the user wants to stay on the major they have.
 
 - Same-owner actions and reusable workflows may use a tag or a SHA. A branch ref such as `@main` is the one form to replace: it moves on every push to that repo, so a compromise there runs here on the next commit with no release step between. Detected by gasa `workflows/action-version-pinning` (medium) and zizmor `unpinned-uses`. `pinact run --branch-to-tag '^main$'` converts the branch to the latest stable tag's SHA when the repo has tags.
 - A repo can carry `.github/pinact.yaml` (`min_age`, `ignore_actions`, `rules`) to encode decisions like "our own org's actions may stay on a tag" or "this tagless reusable workflow stays on `main`"; read it before reporting a pin as a finding, and quote its reason next to the finding (audit precedence rule).
@@ -43,7 +43,7 @@ updates:
       prefix: "[actions] "
 ```
 
-  Without `cooldown`, Dependabot proposes the fresh SHA on release day and quietly undoes the 7-day rule. Detected by zizmor `dependabot-cooldown` (`--collect all`) and gasa `updates/update-tool-configuration`, `updates/update-tool-actions-cooldown`, `updates/update-tool-actions-pinning`.
+Without `cooldown`, Dependabot proposes the fresh SHA on release day and quietly undoes the 7-day rule. Detected by zizmor `dependabot-cooldown` (`--collect all`) and gasa `updates/update-tool-configuration`, `updates/update-tool-actions-cooldown`, `updates/update-tool-actions-pinning`.
 
 ## Credentials: OIDC over static secrets
 


### PR DESCRIPTION
Part 9 of 11 in stack #13 (`gha-skill/fmt`, base `gha-skill/pinact`). Review bottom-up; each layer was diff-reviewed before its commit.

## Changes
- **Format Markdown and JSON with prettier; add make fmt and lint-fmt** — Matches super-linter's MARKDOWN_PRETTIER and JSON_PRETTIER defaults so CI and local runs agree. Tables are now column-aligned.

## Verification
- `make lint` clean (markdownlint, prettier, yamllint, shellcheck, py_compile, actionlint, zizmor, poutine, pinact).
- `make lint` clean at the layer's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011yRNwbvpf198fiYZHgkt1w